### PR TITLE
Update Combat Flow Plugin

### DIFF
--- a/Plugins/InfiltrationEngineTools.rbxmx
+++ b/Plugins/InfiltrationEngineTools.rbxmx
@@ -28,6 +28,8 @@
 					<string name="Name">Main</string>
 					<string name="ScriptGuid">{B9A3E7C5-61BC-4DC4-B716-0384D74E6DE0}</string>
 					<ProtectedString name="Source"><![CDATA[local HttpService = game:GetService("HttpService")
+local UIS = game:GetService("UserInputService")
+
 local VisibilityToggle = require(script.Parent.Parent.Util.VisibilityToggle)
 
 local module = {}
@@ -36,7 +38,7 @@ local DrawnModel = nil
 local ClickConnection = nil
 local CurrentMap = nil
 
-local BLUE = Color3.fromRGB(110, 153, 202)
+local BLUE = Color3.new(0, 0, 0.8)
 local BLACK = Color3.fromRGB(0, 0, 0)
 local WHITE = Color3.new(1, 1, 1)
 
@@ -54,6 +56,23 @@ local function LinkId(id0, id1)
 		return id0 .. "|" .. id1
 	end
 	return id1 .. "|" .. id0
+end
+
+local function ToggleNodeLink(node1, node2)
+	local node1Links = HttpService:JSONDecode(node1:GetAttribute("LinkedIds") or "[]")
+	local node2Links = HttpService:JSONDecode(node2:GetAttribute("LinkedIds") or "[]")
+
+	local idx = table.find(node1Links, node2.Name)
+	if idx == nil then
+		table.insert(node1Links, node2.Name)
+		table.insert(node2Links, node1.Name)
+	else
+		table.remove(node1Links, idx)
+		table.remove(node2Links, table.find(node2Links, node1.Name))
+	end
+
+	node1:SetAttribute("LinkedIds", HttpService:JSONEncode(node1Links))
+	node2:SetAttribute("LinkedIds", HttpService:JSONEncode(node2Links))
 end
 
 function module.Init(mouse: PluginMouse)
@@ -97,8 +116,13 @@ function module.Init(mouse: PluginMouse)
 			for _, targetId in linkTo do
 				local linkName = LinkId(checkId, targetId)
 
+				if DrawnModel:FindFirstChild(linkName) ~= nil then
+					-- Node link already exists, don't create a second one
+					continue
+				end
+
 				local linkPart = CurrentMap:FindFirstChild(targetId)
-				local p = DrawLine(part.Position, linkPart.Position, Color3.new(0, 0, 0.8), BLUE)
+				local p = DrawLine(part.Position, linkPart.Position, BLUE)
 				p.Parent = DrawnModel
 				p.Name = linkName
 
@@ -118,26 +142,54 @@ function module.Init(mouse: PluginMouse)
 		part.Color = BLACK
 	end
 
-	ClickConnection = mouse.Button1Down:Connect(function(target)
+	ClickConnection = UIS.InputBegan:Connect(function(input, processed)
+		-- Only act on mouse inputs
+		if input.UserInputType ~= Enum.UserInputType.MouseButton1 then return end
+
+		-- If the mouse button being pressed was to interact with UI, do nothing
+		if processed then return end
+
 		local part = mouse.Target
-		if part:IsDescendantOf(workspace.DebugMission.CombatFlowMap) then
+		local wasCtrlPressed = input:IsModifierKeyDown(Enum.ModifierKey.Ctrl)
+		local partIsFlowNode = part:IsDescendantOf(workspace.DebugMission.CombatFlowMap) 
+
+		if partIsFlowNode and not wasCtrlPressed then
 			CurrentMap = part.Parent
+
 			for _, p in CurrentMap:GetChildren() do
 				p.Name = p:GetAttribute("Id")
+				if p.Name == part.Name and p ~= part then
+					-- Duplicate part IDs, emit warn
+					warn(`Encountered Combat Flow Nodes with duplicate ID of {p.Name} - combat flow may behave unexpectedly`)
+				end
 			end
 
 			local id = part:GetAttribute("Id")
 			game.Selection:Set({ part })
 
 			RedrawMap(id)
-		elseif part.Name:match("|") and #part.Name == 73 then
+		elseif partIsFlowNode and wasCtrlPressed then
+			local firstNode = game.Selection:Get()[1]
+
+			-- Current selection isn't flow node, do nothing
+			if not firstNode:IsDescendantOf(workspace.DebugMission.CombatFlowMap) then return end
+
+			-- Both are flow nodes but are from different maps so can't join them
+			if firstNode.Parent ~= part.Parent then warn(`Attempt to join combat flow nodes {firstNode.Name} and {part.Name} from differing flow maps!`) return end
+
+			ToggleNodeLink(firstNode, part)
+
+			RedrawMap(firstNode:GetAttribute("Id")) -- Sets FilteredLinks
+		elseif part.Name:match("|") and #part.Name >= 3 then
 			local node = game.Selection:Get()[1]
 			local blocked = node:GetAttribute("BlockedLinks") or "{}"
 			blocked = game:GetService("HttpService"):JSONDecode(blocked)
 
-			blocked[part.Name] = if not blocked[part.Name] then true else nil
+			local beingBlocked = not blocked[part.Name]
+			blocked[part.Name] = if beingBlocked then true else nil
 
 			node:SetAttribute("BlockedLinks", HttpService:JSONEncode(blocked))
+
 			RedrawMap(node.Name)
 		else
 			local id0, id1 = part.Name:match("|")
@@ -165,6 +217,7 @@ function module.Clean()
 end
 
 return module
+
 ]]></ProtectedString>
 					<int64 name="SourceAssetId">-1</int64>
 					<BinaryString name="Tags"></BinaryString>

--- a/Plugins/src/InfiltrationEngineTools/CombatMap/Main.lua
+++ b/Plugins/src/InfiltrationEngineTools/CombatMap/Main.lua
@@ -1,4 +1,6 @@
 local HttpService = game:GetService("HttpService")
+local UIS = game:GetService("UserInputService")
+
 local VisibilityToggle = require(script.Parent.Parent.Util.VisibilityToggle)
 
 local module = {}
@@ -7,7 +9,7 @@ local DrawnModel = nil
 local ClickConnection = nil
 local CurrentMap = nil
 
-local BLUE = Color3.fromRGB(110, 153, 202)
+local BLUE = Color3.new(0, 0, 0.8)
 local BLACK = Color3.fromRGB(0, 0, 0)
 local WHITE = Color3.new(1, 1, 1)
 
@@ -25,6 +27,23 @@ local function LinkId(id0, id1)
 		return id0 .. "|" .. id1
 	end
 	return id1 .. "|" .. id0
+end
+
+local function ToggleNodeLink(node1, node2)
+	local node1Links = HttpService:JSONDecode(node1:GetAttribute("LinkedIds") or "[]")
+	local node2Links = HttpService:JSONDecode(node2:GetAttribute("LinkedIds") or "[]")
+	
+	local idx = table.find(node1Links, node2.Name)
+	if idx == nil then
+		table.insert(node1Links, node2.Name)
+		table.insert(node2Links, node1.Name)
+	else
+		table.remove(node1Links, idx)
+		table.remove(node2Links, table.find(node2Links, node1.Name))
+	end
+	
+	node1:SetAttribute("LinkedIds", HttpService:JSONEncode(node1Links))
+	node2:SetAttribute("LinkedIds", HttpService:JSONEncode(node2Links))
 end
 
 function module.Init(mouse: PluginMouse)
@@ -68,8 +87,13 @@ function module.Init(mouse: PluginMouse)
 			for _, targetId in linkTo do
 				local linkName = LinkId(checkId, targetId)
 
+				if DrawnModel:FindFirstChild(linkName) ~= nil then
+					-- Node link already exists, don't create a second one
+					continue
+				end
+
 				local linkPart = CurrentMap:FindFirstChild(targetId)
-				local p = DrawLine(part.Position, linkPart.Position, Color3.new(0, 0, 0.8), BLUE)
+				local p = DrawLine(part.Position, linkPart.Position, BLUE)
 				p.Parent = DrawnModel
 				p.Name = linkName
 
@@ -89,26 +113,54 @@ function module.Init(mouse: PluginMouse)
 		part.Color = BLACK
 	end
 
-	ClickConnection = mouse.Button1Down:Connect(function(target)
+	ClickConnection = UIS.InputBegan:Connect(function(input, processed)
+		-- Only act on mouse inputs
+		if input.UserInputType ~= Enum.UserInputType.MouseButton1 then return end
+		
+		-- If the mouse button being pressed was to interact with UI, do nothing
+		if processed then return end
+		
 		local part = mouse.Target
-		if part:IsDescendantOf(workspace.DebugMission.CombatFlowMap) then
+		local wasCtrlPressed = input:IsModifierKeyDown(Enum.ModifierKey.Ctrl)
+		local partIsFlowNode = part:IsDescendantOf(workspace.DebugMission.CombatFlowMap) 
+		
+		if partIsFlowNode and not wasCtrlPressed then
 			CurrentMap = part.Parent
+
 			for _, p in CurrentMap:GetChildren() do
 				p.Name = p:GetAttribute("Id")
+				if p.Name == part.Name and p ~= part then
+					-- Duplicate part IDs, emit warn
+					warn(`Encountered Combat Flow Nodes with duplicate ID of {p.Name} - combat flow may behave unexpectedly`)
+				end
 			end
 
 			local id = part:GetAttribute("Id")
 			game.Selection:Set({ part })
 
 			RedrawMap(id)
-		elseif part.Name:match("|") and #part.Name == 73 then
+		elseif partIsFlowNode and wasCtrlPressed then
+			local firstNode = game.Selection:Get()[1]
+			
+			-- Current selection isn't flow node, do nothing
+			if not firstNode:IsDescendantOf(workspace.DebugMission.CombatFlowMap) then return end
+			
+			-- Both are flow nodes but are from different maps so can't join them
+			if firstNode.Parent ~= part.Parent then warn(`Attempt to join combat flow nodes {firstNode.Name} and {part.Name} from differing flow maps!`) return end
+			
+			ToggleNodeLink(firstNode, part)
+
+			RedrawMap(firstNode:GetAttribute("Id")) -- Sets FilteredLinks
+		elseif part.Name:match("|") and #part.Name >= 3 then
 			local node = game.Selection:Get()[1]
 			local blocked = node:GetAttribute("BlockedLinks") or "{}"
 			blocked = game:GetService("HttpService"):JSONDecode(blocked)
 
-			blocked[part.Name] = if not blocked[part.Name] then true else nil
+			local beingBlocked = not blocked[part.Name]
+			blocked[part.Name] = if beingBlocked then true else nil
 
 			node:SetAttribute("BlockedLinks", HttpService:JSONEncode(blocked))
+
 			RedrawMap(node.Name)
 		else
 			local id0, id1 = part.Name:match("|")
@@ -136,3 +188,4 @@ function module.Clean()
 end
 
 return module
+


### PR DESCRIPTION
The current combat flow plugin re-renders the entire selected flow map with every change, this patch corrects this behaviour

This patch also removes the requirement that all flow node link names must be precisely 73 characters in length to allow for the plugin to function as intended with node names that aren't 32 characters in length - this allows for users to create flow nodes with human readable names should they so desire

To avoid the loosened naming requirements causing ID collisions, a warning has been added should the plugin encounter any duplicate IDs