### PR TITLE
Cell Marker // Modifier Keys + Usability Improvements

### DIFF
--- a/Plugins/src/InfiltrationEngineTools/ZoneMarker/Main.lua
+++ b/Plugins/src/InfiltrationEngineTools/ZoneMarker/Main.lua
@@ -5,22 +5,73 @@ local VisibilityToggle = require(script.Parent.Parent.Util.VisibilityToggle)
 local UserInputService = game:GetService("UserInputService")
 
 local MAX_PROJECT = 50
+
 local SIZE_PADDING = 1
 local POSITION_SINK = 0.3
 
 local CellFolder
 local Events = {}
 local Ghost
+local HoveringCell
+
 local MouseDown = false
+local ShiftDown = false
+local CtrlDown = false
 
 local GhostCfr
 local GhostSize
 local GhostMax
 local GhostMin
 
-local CastParams = RaycastParams.new()
+local WithPropCastParams = RaycastParams.new()
+local NoPropCastParams = RaycastParams.new()
+NoPropCastParams.FilterType = Enum.RaycastFilterType.Exclude
+
+local CellCastParams = RaycastParams.new()
+CellCastParams.FilterType = Enum.RaycastFilterType.Include
+
+local function GetLevelRoot()
+	return workspace:FindFirstChild("DebugMission") or workspace:FindFirstChild("Level")
+end
+
+local function CreateTempDoorFolder()
+	local levelRoot = GetLevelRoot()
+	local propFolder = levelRoot and levelRoot:FindFirstChild("Props")
+	if not propFolder then return end
+
+	local doorsFolderTemp = Instance.new("Folder")
+	doorsFolderTemp.Name = "CellMarkerDoorsTemp"
+	doorsFolderTemp.Parent = workspace
+
+	for _, prop in pairs(propFolder:GetChildren()) do
+		if prop.Name:find("Door") == nil then continue end
+		local tempDoor = prop:Clone()
+		tempDoor.Parent = doorsFolderTemp
+	end
+end
+
+local function CleanupTempDoorFolder()
+	local doorsFolderTemp = workspace:FindFirstChild("CellMarkerDoorsTemp")
+	if not doorsFolderTemp then return end
+	doorsFolderTemp:Destroy()
+end
+
+local function UpdatePropCastExcludeList()
+	local levelRoot = GetLevelRoot()
+	NoPropCastParams.FilterDescendantsInstances = {
+		levelRoot and levelRoot:FindFirstChild("Props") or nil,
+		levelRoot and levelRoot:FindFirstChild("CombatFlowMap") or nil,
+		levelRoot and levelRoot:FindFirstChild("Nodes") or nil,
+		levelRoot and levelRoot:FindFirstChild("MapData") or nil
+	}
+end
+
 local function GetProjectionDist(basePos, axis)
-	local result = workspace:Raycast(basePos, axis * MAX_PROJECT, CastParams)
+	local castParams = CtrlDown and WithPropCastParams or NoPropCastParams
+
+	local castDistance = ShiftDown and 1_000_000 or MAX_PROJECT
+
+	local result = workspace:Raycast(basePos, axis * castDistance, castParams)
 	if result then
 		return (result.Position - basePos).magnitude
 	else
@@ -28,22 +79,48 @@ local function GetProjectionDist(basePos, axis)
 	end
 end
 
-local function UpdateGhost(basePos, axis0, axis1)
+local function UpdateGhost(basePos, axis0, axis1, mouseDown)
+	if mouseDown then
+		Ghost.Transparency = 0.0
+		return
+	else
+		Ghost.Transparency = 0.5
+	end
+	
 	local z0, z1 = GetProjectionDist(basePos, axis0), GetProjectionDist(basePos, -axis0)
 	local x0, x1 = GetProjectionDist(basePos, axis1), GetProjectionDist(basePos, -axis1)
-	
+
 	local pos = basePos + axis0 * (z0 - z1) / 2 + axis1 * (x0 - x1) / 2
 	GhostCfr = CFrame.new(pos, pos + axis0)
 	GhostSize = Vector3.new(x0 + x1, 0.2, z0 + z1)
 	GhostMax = GetProjectionDist(basePos, Vector3.new(0, 1, 0))
 	GhostMin = GetProjectionDist(basePos, Vector3.new(0, -1, 0))
-	
-	if GhostMax == MAX_PROJECT then
+
+	if GhostMax == MAX_PROJECT and not ShiftDown then
 		GhostMax = GhostMax - GhostMin
 	end
-	
+
 	Ghost.CFrame = GhostCfr
 	Ghost.Size = GhostSize
+end
+
+local function UpdateHoveringCell(pos, mouseDown)
+	if HoveringCell then
+		-- Reveal previously hovered cell
+		for _, p in pairs(HoveringCell:GetChildren()) do
+			p.Transparency = 0.5
+		end
+	end
+	
+	if not MouseDown then return end
+	
+	local hoveringCell = GetZone(pos)
+	if not hoveringCell then return end
+	
+	HoveringCell = hoveringCell
+	for _, p in pairs(hoveringCell:GetChildren()) do
+		p.Transparency = 0
+	end
 end
 
 local function ReoptimizeCells()
@@ -134,7 +211,7 @@ local function hashName(name)
 	if name == "Default" then
 		return Color3.new(0, 0, 0)
 	end
-	
+
 	local h = 5^7
 	local n = 0
 	for i = 1, #name do
@@ -156,7 +233,7 @@ end
 local function CreateCell(mousePos)
 	local cellModel = GetZone(mousePos)
 	local addFloor = true
-	
+
 	if cellModel then
 		addFloor = false
 		print("Add to:", cellModel:GetFullName())
@@ -167,20 +244,23 @@ local function CreateCell(mousePos)
 		cellModel.Name = "Default"
 		cellModel.Parent = LevelBase.Cells
 	end
-	
+
 	local roof = Ghost:Clone()
 	roof.Size = roof.Size + Vector3.new(SIZE_PADDING * 2, 0.8, SIZE_PADDING * 2)
 	roof.CFrame = GhostCfr * CFrame.new(0, GhostMax + POSITION_SINK, 0)
 	roof.Name = "Roof"
 	roof.Parent = cellModel
 	roof.Anchored = true
-	
+	roof.Transparency = 0.5
+	roof.CastShadow = false
+
 	if addFloor then
 		local floor = roof:Clone()
 		floor.Name = "Floor"
 		floor.CFrame = GhostCfr * CFrame.new(0, -GhostMin - POSITION_SINK, 0)
 		floor.Parent = cellModel
 		floor.Anchored = true
+		floor.CastShadow = false
 	else
 		ReoptimizeCells()
 	end
@@ -193,31 +273,37 @@ return {
 			l.Name = "Level"
 			l.Parent = workspace
 		end
-		local LevelBase = workspace:FindFirstChild("DebugMission") or workspace:FindFirstChild("Level")
+
+		local LevelBase = GetLevelRoot()
 		if not LevelBase:FindFirstChild("Cells") then
 			local c = Instance.new("Folder")
 			c.Name = "Cells"
 			c.Parent = LevelBase
 		end
-		
+
+		UpdatePropCastExcludeList()
+		CreateTempDoorFolder()
+
 		Ghost = Instance.new("Part")
 		Ghost.Color = Color3.new(0, 0, 0)
 		Ghost.Transparency = 0.5
 		Ghost.Parent = LevelBase.Cells
-		
+		Ghost.CastShadow = false
+
 		CellFolder = LevelBase.Cells
 		mouse.TargetFilter = CellFolder
-		CastParams.FilterType = Enum.RaycastFilterType.Blacklist
-		CastParams.FilterDescendantsInstances = { CellFolder }
-		
-		Events[1] = game["Run Service"].RenderStepped:connect(function()
-			if mouse.Target and not MouseDown then
+		WithPropCastParams.FilterType = Enum.RaycastFilterType.Exclude
+		WithPropCastParams.FilterDescendantsInstances = { CellFolder }
+
+		Events[1] = game:GetService("RunService").RenderStepped:connect(function()
+			if mouse.Target then
 				local v0, v1 = AxisAlign.CameraAlign(mouse.Target.CFrame)
 				local origin = mouse.Hit.p - mouse.UnitRay.Direction * 0.5
-				UpdateGhost(origin, v0, v1)
+				UpdateGhost(origin, v0, v1, MouseDown)
+				UpdateHoveringCell(mouse.Hit.p, MouseDown)
 			end
 		end)
-		
+
 		Events[2] = mouse.Button1Up:connect(function()
 			CreateCell(mouse.Hit.p)
 			MouseDown = false
@@ -226,8 +312,10 @@ return {
 		Events[3] = mouse.Button1Down:connect(function()
 			MouseDown = true
 		end)
-		
-		Events[3] = UserInputService.InputBegan:connect(function(io)
+
+		Events[4] = UserInputService.InputBegan:connect(function(io)
+			ShiftDown = io:IsModifierKeyDown(Enum.ModifierKey.Shift)
+			CtrlDown  = io:IsModifierKeyDown(Enum.ModifierKey.Ctrl )
 			if io.KeyCode == Enum.KeyCode.T then
 				ReoptimizeCells()
 			elseif io.KeyCode == Enum.KeyCode.G then
@@ -242,9 +330,14 @@ return {
 				ShowLinks()
 			end
 		end)
+		
+		Events[5] = UserInputService.InputEnded:Connect(function(io)
+			ShiftDown = io:IsModifierKeyDown(Enum.ModifierKey.Shift)
+			CtrlDown  = io:IsModifierKeyDown(Enum.ModifierKey.Ctrl )
+		end)
 
 		VisibilityToggle.TempReveal(workspace.DebugMission.Cells)
-		
+
 		print([[T - Reoptimize Cell Floors
 		G - Show All Cells
 		H - Hide All Cells
@@ -263,5 +356,6 @@ return {
 			Ghost:Destroy()
 			Ghost = nil
 		end
+		CleanupTempDoorFolder()
 	end,
 }


### PR DESCRIPTION
Would like to preface this description by apologizing for having more than one PR open :sweat_smile: - feel free to look at both of these at your convenience

This PR adds support for two new features whilst holding the corresponding modifier keys:
`Shift` - Disable max raycast distance, for the occasional room larger than 100 studs
`CTRL` - Raycast through Props, combat flow nodes, pathing nodes, and map data, for rooms already decorated

Furthermore, some usability tweaks have been made to hopefully make the tool feel more responsive, mostly done by setting the transparency of certain cell parts to zero when the left mouse button is held down

As with my other open PR, no changes to the plugin rbxm are included

Thanks