### PR TITLE
Serializer // MeshPart Readback Support

### DIFF
--- a/Plugins/src/SerializationTools/Reading/Read.lua
+++ b/Plugins/src/SerializationTools/Reading/Read.lua
@@ -5,6 +5,8 @@ local Materials = require(script.Parent.Parent.Types.Materials)
 local PartTypes = require(script.Parent.Parent.Types.PartTypes)
 local NormalId = require(script.Parent.Parent.Types.NormalId)
 local MeshType = require(script.Parent.Parent.Types.MeshType)
+local RenderFidelity = require(script.Parent.Parent.Types.RenderFidelity)
+local CollisionFidelity = require(script.Parent.Parent.Types.CollisionFidelity)
 
 local VersionConfig = require(script.Parent.Parent.Util.VersionConfig)
 
@@ -196,6 +198,8 @@ Read = {
 	PartType = CreateEnumReader(Enum.PartType, PartTypes),
 	NormalId = CreateEnumReader(Enum.NormalId, NormalId),
 	MeshType = CreateEnumReader(Enum.MeshType, MeshType),
+	RenderFidelity = CreateEnumReader(Enum.RenderFidelity, RenderFidelity),
+	CollisionFidelity = CreateEnumReader(Enum.CollisionFidelity, CollisionFidelity),
 }
 
 return Read

--- a/Plugins/src/SerializationTools/Types/CollisionFidelity.lua
+++ b/Plugins/src/SerializationTools/Types/CollisionFidelity.lua
@@ -1,0 +1,6 @@
+return {
+	Default = 0,
+	Hull = 1,
+	Box = 2,
+	PreciseConvexDecomposition = 3,
+}

--- a/Plugins/src/SerializationTools/Types/InstanceProperties.lua
+++ b/Plugins/src/SerializationTools/Types/InstanceProperties.lua
@@ -54,6 +54,9 @@ InstanceProperties = { -- any changes to this table should be changed in Instanc
 		{ "CastShadow", "Bool", false },
 		{ "MeshId", "String", "" },
 		{ "TextureID", "String", "" },
+		{ "DoubleSided", "Bool", false },
+		{ "RenderFidelity", "RenderFidelity", "Automatic" },
+		{ "CollisionFidelity", "CollisionFidelity", "Default" }
 	},
 	UnionOperation = {
 		{ "Name", "String", "Part" },

--- a/Plugins/src/SerializationTools/Types/RenderFidelity.lua
+++ b/Plugins/src/SerializationTools/Types/RenderFidelity.lua
@@ -1,0 +1,5 @@
+return {
+	Automatic = 0,
+	Precise = 1,
+	Performance = 2
+}

--- a/Plugins/src/SerializationTools/Writing/Write.lua
+++ b/Plugins/src/SerializationTools/Writing/Write.lua
@@ -5,6 +5,8 @@ local Materials = require(script.Parent.Parent.Types.Materials)
 local PartTypes = require(script.Parent.Parent.Types.PartTypes)
 local NormalId = require(script.Parent.Parent.Types.NormalId)
 local MeshType = require(script.Parent.Parent.Types.MeshType)
+local RenderFidelity = require(script.Parent.Parent.Types.RenderFidelity)
+local CollisionFidelity = require(script.Parent.Parent.Types.CollisionFidelity)
 
 local VersionConfig = require(script.Parent.Parent.Util.VersionConfig)
 
@@ -228,6 +230,8 @@ Write = {
 	PartType = CreateEnumWriter(PartTypes),
 	NormalId = CreateEnumWriter(NormalId),
 	MeshType = CreateEnumWriter(MeshType),
+	RenderFidelity = CreateEnumWriter(RenderFidelity),
+	CollisionFidelity = CreateEnumWriter(CollisionFidelity),
 	--[[
 	Material = function(material)
 		return StringConversion.NumberToString(Materials[material.Name], 1)


### PR DESCRIPTION
Adds support for use of arbitrary MeshParts in missions via InsertService - tested to work by reimporting from ReplicatedStorage

Adds DoubleSided, CollisionFidelity, and RenderFidelity properties to MeshParts - including support for the relevant Enums

Shouldn't require a code format version bump