### PR TITLE
Serializer // Studio Cross-Plugin API Support

### DIFF
--- a/Plugins/src/SerializationTools/API/APIConsumer.lua
+++ b/Plugins/src/SerializationTools/API/APIConsumer.lua
@@ -1,0 +1,126 @@
+--[[
+	This module is provided for convenience of consumers of the serializer API
+	providing a reference implementation for correctly retrieving and validating a reference to the API table
+
+	For a working example of a plugin making use of this API via this module
+	see: https://github.com/Sprixitite/InfiltrationEngine-PrefabSystem
+]]
+
+local coreGui = game:GetService("CoreGui")
+
+export type Token = string
+export type Hook = (...any) -> nil
+export type HookType = "APIExtensionLoaded"|"APIExtensionUnloaded"|"PreSerialize"|"SerializerUnloaded"
+export type APIExtension = { [string] : (...any) -> ...any }
+
+export type APIReference = {
+	-- Generic
+	GetAPIVersion 		: () -> number,
+	GetCodeVersion 		: () -> number,
+	GetAttributesMap 	: () -> { [string] : { [number] : any } },
+	GetAttributeTypes 	: () -> { [string] : number },
+
+	-- HookTypes
+	GetHookTypes 		: () -> { [number] : string },
+	IsHookTypeValid 	: (hookType: string, warnCaller: string?) -> boolean,
+
+	-- Hooks
+	AddHook 			: (hookType: HookType, registrant: string, hook: Hook, hookState: {any}?) -> Token,
+	RemoveHook 			: (token: Token) -> nil,
+
+	-- APIExtensions
+	AddAPIExtension 	: (name: string, author: string, contents: APIExtension) -> Token,
+	GetAPIExtension		: (name: string, author: string) -> APIExtension,
+	RemoveAPIExtension	: (token: Token) -> nil
+}
+
+type AnyTbl = { [string] : any }
+
+local APIConsumer = {}
+
+local function ValidateArgTypes(fname: string, ...) : boolean
+	local args = {...}
+	for _, argSettings in ipairs(args) do
+		local argName = argSettings[1]
+		local argValue = argSettings[2]
+		local argType = type(argValue)
+		local argExpectedType = argSettings[3]
+		if argType ~= argExpectedType then
+			warn(`Invalid argument {argName} passed to function {fname} - expected type {argExpectedType} but got {argType}!`)
+			return false
+		end
+	end
+	return true
+end
+
+APIConsumer.ValidateArgTypes = ValidateArgTypes
+
+-- Yields until timeOut is elapsed or API is found
+APIConsumer.WaitForAPI = function(timeOut: number?) : APIReference?
+	timeOut = if timeOut == nil then math.huge else timeOut
+
+	if not ValidateArgTypes(
+		"WaitForAPI",
+		{"timeOut", timeOut, "number"}
+		) then return end
+
+	local presenceIndicator = coreGui:WaitForChild("InfilEngine_SerializerAPIAvailable", timeOut)
+	if not presenceIndicator then return end
+
+	local apiTbl = shared.InfilEngine_SerializerAPI
+	if not (tostring(apiTbl) == presenceIndicator.Value) then return end
+
+	return apiTbl
+end
+
+-- Never returns unless there's an error
+-- Continually wires up handling of serializer load/unload as well as unloading of consumer plugin as needed
+-- Avoid doing this yourself if you can help it
+APIConsumer.DoAPILoop = function<StateT>(
+	callerPlugin: Plugin,
+	srcname: string,
+	loadedClbck: (api: APIReference, state: StateT) -> nil,
+	unloadedClbck: (api: APIReference, state: StateT) -> nil, 
+	state: StateT?
+) : never
+	state = if state == nil then {} else state
+
+	if typeof(callerPlugin) ~= "Instance" then
+		warn(`Invalid argument callerPlugin passed to DoAPILoop - expected type Plugin but got {typeof(callerPlugin)}!`)
+		return
+	end
+
+	if callerPlugin.ClassName ~= "Plugin" then
+		warn(`Invalid argument callerPlugin passed to DoAPILoop - expected type Plugin but got {callerPlugin.ClassName}!`)
+		return
+	end
+
+	if not ValidateArgTypes(
+		"DoAPILoop", 
+		{"srcname", srcname, "string"},
+		{"loadedClbck", loadedClbck, "function"},
+		{"unloadedClbck", unloadedClbck, "function"},
+		{"state", state, "table"}
+		) then return end
+
+	local api = APIConsumer.WaitForAPI()
+	if api == nil then return APIConsumer.DoAPILoop(callerPlugin, srcname, loadedClbck, unloadedClbck, state) end
+
+	loadedClbck(api, state)
+
+	local pluginUnloadCallback
+
+	pluginUnloadCallback = callerPlugin.Unloading:Connect(function()
+		pluginUnloadCallback:Disconnect()
+		pluginUnloadCallback = nil
+		unloadedClbck(api, state)
+	end)
+
+	api.AddHook("SerializerUnloaded", `APIConsumerFramework_{srcname}`, function()
+		if pluginUnloadCallback then pluginUnloadCallback:Disconnect() pluginUnloadCallback = nil end
+		unloadedClbck(api, state)
+		APIConsumer.DoAPILoop(callerPlugin, srcname, loadedClbck, unloadedClbck, state)
+	end)
+end
+
+return APIConsumer

--- a/Plugins/src/SerializationTools/API/Internal.lua
+++ b/Plugins/src/SerializationTools/API/Internal.lua
@@ -1,0 +1,117 @@
+local httpService = game:GetService("HttpService")
+
+local attributesMap = require(script.Parent.Parent.AttributesMap)
+
+local internalAPI = {}
+internalAPI.APIExtensions = {}
+
+internalAPI.Hooks = {}
+internalAPI.Hooks.APIExtensionLoaded = {}
+internalAPI.Hooks.APIExtensionUnloaded = {}
+internalAPI.Hooks.PreSerialize = {}
+internalAPI.Hooks.SerializerUnloaded = {}
+
+internalAPI.HookTypes = {}
+
+internalAPI.AddTokenData = function(tbl, data)
+	local id = httpService:GenerateGUID(false)
+	tbl[id] = data
+	return id
+end
+
+internalAPI.RemoveTokenData = function(tbl, token, hookName)
+	if tbl[token] == nil then
+		warn(`Attempt made to remove {hookName} using invalid GUID!`)
+		return
+	end
+	tbl[token] = nil
+end
+
+internalAPI.AddHook = function(hookType: string, registrant, callback, state) : string
+	local hookTbl = internalAPI.Hooks[hookType]
+	return internalAPI.AddTokenData(
+		hookTbl, 
+		{ 
+			Registrant = registrant,
+			Callback = callback,
+			CallbackState = state
+		}
+	)
+end
+
+internalAPI.RemoveHook = function(hookType: string, token: string)
+	local hookName = `{hookType}Hook`
+	local hookTbl = internalAPI.Hooks[hookType]
+	internalAPI.RemoveTokenData(hookTbl, token, hookName)
+end
+
+internalAPI.InvokeHook = function(hookType, ...)
+	for _, hook in pairs(internalAPI.Hooks[hookType]) do
+		--[[
+			Nil here for future extensions without needing to bump API version
+
+			The hope is adding a dynamic phase-based invocation system whereby we pass an "InvocationState"
+				describing which callbacks have finished and which haven't, giving hooks read-only access to this
+				and then letting them run as coroutines, yielding if a dependency has yet to run
+		
+			Any values returned by a yielding callback may then be published to the InvocationState for other hooks to read
+				allowing for the export of useful intermediary data from partway through a hooks execution
+		
+			This allows a way to opt-in to deterministic execution order while also allowing for
+				intercommunication of useful data without adding an explicit priority system
+		]]
+		local success, reason = pcall(hook.Callback, hook.CallbackState, nil, ...)
+
+		if not success then
+			warn(`Error encountered when running {hookType}Hook {hook.Registrant} - {reason}`)
+		end
+	end
+end
+
+function internalAPI.GetHookTypes()
+	return internalAPI.HookTypes
+end
+
+internalAPI.AddAPIExtension = function(name, author, contents)
+	for _, apiExtension in pairs(internalAPI.APIExtensions) do
+		if apiExtension.Name.Name == name then
+			warn(`APIExtension naming collision! Name \"{name}\" already in use!`)
+			return
+		end
+	end
+
+	local id = internalAPI.AddTokenData(
+		internalAPI.APIExtensions,
+		{
+			Name = name,
+			Author = author,
+			Contents = contents
+		}
+	)
+
+	internalAPI.InvokeHook("APIExtensionLoaded", name, author, contents)
+	return id
+end
+
+internalAPI.GetAPIExtension = function(name, author)
+	for _, extension in internalAPI.APIExtensions do
+		if extension.Name == name and extension.Author == author then return extension.Contents end
+	end
+end
+
+internalAPI.RemoveAPIExtension = function(guid)
+	local removing = internalAPI.APIExtensions[guid]
+	if removing then
+		internalAPI.InvokeHook("APIExtensionUnloaded", removing.Name, removing.Author, removing.Contents)
+	end
+
+	internalAPI.RemoveTokenData(internalAPI.APIExtensions, guid, "APIExtension")
+
+end
+
+for k, _ in pairs(internalAPI.Hooks) do
+	internalAPI.HookTypes[#internalAPI.HookTypes+1] = k
+end
+table.freeze(internalAPI.HookTypes)
+
+return internalAPI

--- a/Plugins/src/SerializationTools/API/Main.lua
+++ b/Plugins/src/SerializationTools/API/Main.lua
@@ -1,0 +1,79 @@
+local coreGui = game:GetService("CoreGui")
+
+local SERIALIZER_INDICATOR_NAME = "InfilEngine_SerializerAPIAvailable"
+
+local serializerAPI = {}
+
+serializerAPI.Public = require(script.Parent.Public)
+serializerAPI.Internal = require(script.Parent.Internal)
+
+serializerAPI.Events = {}
+serializerAPI.PresenceIndicator = nil
+
+function serializerAPI.PresenceIndicatorDestroying()
+	serializerAPI.CreatePresenceIndicator(tostring(serializerAPI.Public), true)
+end
+
+function serializerAPI.PresenceIndicatorChanged()
+	-- Resetting the indicator back would create an infinite loop
+	-- Instead, force the indicator to be re-created
+	serializerAPI.PresenceIndicator:Destroy()
+end
+
+function serializerAPI.CoreGuiChildAdded(child)
+	if child.Name == SERIALIZER_INDICATOR_NAME then
+		if child == serializerAPI.PresenceIndicator then return end
+		warn("Attempted tampering of Serializer API presence indication detected - consider vetting plugins for undesirable behaviour")
+		child:Destroy()
+	end
+end
+
+function serializerAPI.CreatePresenceIndicator(tableId, shouldWarn)
+	if shouldWarn == nil then shouldWarn = true end
+
+	if shouldWarn then warn("Tampering of Serializer API presence indicator detected - consider vetting plugins for undesirable behaviour") end
+
+	local presenceIndicator = Instance.new("StringValue")
+	presenceIndicator.Archivable = false
+	presenceIndicator.Name = SERIALIZER_INDICATOR_NAME
+	presenceIndicator.Value = tableId
+	presenceIndicator.Parent = coreGui
+
+	serializerAPI.CleanIndicatorEvents()
+	serializerAPI.Events[1] = presenceIndicator.Destroying:Connect(serializerAPI.PresenceIndicatorDestroying)
+	serializerAPI.Events[2] = presenceIndicator.Changed:Connect(serializerAPI.PresenceIndicatorChanged)
+	serializerAPI.Events[3] = presenceIndicator.AncestryChanged:Connect(serializerAPI.PresenceIndicatorChanged)
+	serializerAPI.Events[4] = presenceIndicator:GetPropertyChangedSignal("Archivable"):Connect(serializerAPI.PresenceIndicatorChanged)
+	serializerAPI.PresenceIndicator = presenceIndicator
+end
+
+function serializerAPI.AntiTamperInit()
+	for _, child in coreGui:GetChildren() do
+		if child.Name ~= SERIALIZER_INDICATOR_NAME then continue end
+		serializerAPI.CoreGuiChildAdded(child)
+	end
+	serializerAPI.AntiCoreGuiTamper = coreGui.ChildAdded:Connect(serializerAPI.CoreGuiChildAdded)
+end
+
+function serializerAPI.Init()
+	serializerAPI.AntiTamperInit()
+	shared.InfilEngine_SerializerAPI = serializerAPI.Public
+	serializerAPI.CreatePresenceIndicator(tostring(serializerAPI.Public), false)
+end
+
+function serializerAPI.Clean()
+	serializerAPI.CleanIndicatorEvents()
+	serializerAPI.AntiCoreGuiTamper:Disconnect()
+	serializerAPI.PresenceIndicator:Destroy()
+	serializerAPI.PresenceIndicator = nil
+	serializerAPI.Internal.InvokeHook("SerializerUnloaded")
+end
+
+function serializerAPI.CleanIndicatorEvents()
+	for i, e in ipairs(serializerAPI.Events) do
+		e:Disconnect()
+		e = nil
+	end
+end
+
+return serializerAPI

--- a/Plugins/src/SerializationTools/API/Public.lua
+++ b/Plugins/src/SerializationTools/API/Public.lua
@@ -1,0 +1,204 @@
+local httpService = game:GetService("HttpService")
+
+local attributesMap = require(script.Parent.Parent.AttributesMap)
+local attributeTypes = require(script.Parent.Parent.PropAttributeTypes)
+local versionCfg = require(script.Parent.Parent.Util.VersionConfig)
+
+local internalAPI = require(script.Parent.Internal)
+
+local function DeepClone(tbl)
+	local cloned = {}
+	for k, v in pairs(tbl) do
+		if type(v) == "table" then
+			cloned[k] = DeepClone(v)
+		else
+			cloned[k] = v
+		end
+	end
+	return cloned
+end
+
+local function DeepFreeze(tbl)
+	for _, v in pairs(tbl) do
+		if type(v) == "table" then
+			table.freeze(v)
+		end
+	end
+	return table.freeze(tbl)
+end
+
+local function ValidateArgTypes(fname, ...)
+	local args = {...}
+	for _, argSettings in ipairs(args) do
+		local argName = argSettings[1]
+		local argValue = argSettings[2]
+		local argType = type(argValue)
+		local argExpectedType = argSettings[3]
+		if argType ~= argExpectedType then
+			warn(`Invalid argument {argName} passed to API function {fname} - expected type {argExpectedType} but got {argType}!`)
+			return false
+		end
+	end
+	return true
+end
+
+type APIExtension = { [string] : (...any) -> ...any }
+
+local publicAPI = {}
+
+--[[
+	[Returns]
+		1 - Returns an integer describing the current revision of the serializer plugin API
+]]
+function publicAPI.GetAPIVersion() : number
+	return versionCfg.VersionNumber_API
+end
+
+--[[
+	[Returns]
+		1 - Integer describing the current version of the serializer's code format
+]]
+function publicAPI.GetCodeVersion() : number
+	return versionCfg.VersionNumber
+end
+
+--[[
+	[Returns]
+		1 - Frozen copy of internal attributes map
+]]
+local frozenAttributesMap = DeepFreeze(DeepClone(attributesMap))
+function publicAPI.GetAttributesMap() : { [string] : { any } }
+	return frozenAttributesMap
+end
+
+--[[
+	[Returns]
+		1 - Frozen copy of internal attribute types
+]]
+local frozenAttributeTypes = DeepFreeze(DeepClone(attributeTypes))
+function publicAPI.GetAttributeTypes() : { [string] : number }
+	return frozenAttributeTypes
+end
+
+--[[
+	[Returns]
+		1 - Frozen copy of valid hook types table
+]]
+function publicAPI.GetHookTypes() : { string }
+	return internalAPI.GetHookTypes()
+end
+
+--[[
+	[Args]
+		     Title // Description                                                                                // Example        //
+		---------- // ------------------------------------------------------------------------------------------ // -------------- //
+		  hookType // String corresponding to the hookType you're attempting to validate                         // "PreSerialize" //
+		warnCaller // String corresponding to the name of the caller - if provided, an automated warn is emitted // "MyFunction"   //
+	[Returns]
+		1 - Boolean indicating whether or not the provided HookType is valid
+]]
+function publicAPI.IsHookTypeValid(hookType: string, warnCaller: string?) : boolean
+	if not ValidateArgTypes("IsHookTypeValid", {"hookType", hookType, "string"}) then return false end
+	local isValid = table.find(publicAPI.GetHookTypes(), hookType) ~= nil
+	if not isValid and warnCaller ~= nil then
+		warn(`Invalid HookType {hookType} passed to function {warnCaller}!`)
+	end
+	return isValid
+end
+
+--[[
+	[Args]
+		     Title // Description                                                                       // Example                                   //
+		---------- // --------------------------------------------------------------------------------- // ----------------------------------------- //
+		  hookType // String corresponding to the type of hook being removed                            // "PreSerialize"                            //
+		registrant // String representing the source of the hook. May be non-unique                     // "MyPlugin"                                //
+		      hook // Function to be invoked when the corresponding hookType is used                    // function() print("Hook!") end             //
+		 hookState // (Optional) Extra state to be passed as the last argument to the hook when invoked // { PartCol = Color3.fromHex("#FFFFFF") } //
+	[Returns]
+		1 - Token which may be later used to securely de-register the hook
+	[Notes]
+		1) All valid hookTypes may be retrieved by calling GetHookTypes
+]]
+function publicAPI.AddHook(hookType: string, registrant: string, hook: (...any) -> nil, hookState: { any }?) : string
+	hookState = if hookState == nil then {} else hookState
+	if not ValidateArgTypes(
+		"AddHook", 
+		{"hookType", hookType, "string"},
+		{"registrant", registrant, "string"},
+		{"hook", hook, "function"},
+		{"hookState", hookState, "table"}
+		) then return end
+	if not publicAPI.IsHookTypeValid(hookType, "AddHook") then return end
+	local token = internalAPI.AddHook(hookType, registrant, hook, hookState) 
+	return `{hookType}_{token}`
+end
+
+--[[
+	[Args]
+		   Title // Description                                            // Example        //
+		-------- // ------------------------------------------------------ // -------------- // 
+		   token // Value returned from corresponding call to AddHook      // n/a            //
+]]
+function publicAPI.RemoveHook(token: string)
+	if not ValidateArgTypes(
+		"RemoveHook",
+		{"token", token, "string"}
+		) then return end
+	local splitToken = string.split(token, "_")
+	if #splitToken ~= 2 then warn("Token provided to RemoveHook is invalid!") return end
+	
+	local hookType = splitToken[1]
+	local realToken = splitToken[2]
+	
+	if not publicAPI.IsHookTypeValid(hookType, "RemoveHook") then return end
+	
+	internalAPI.RemoveHook(hookType, realToken)
+end
+
+--[[
+	[Args] 
+		   Title // Description                                       // Example                                                //
+	    -------- // ------------------------------------------------- // ------------------------------------------------------ //
+		    name // Name of the API extension                         // "MyPluginAPI"                                          //
+		  author // Name/alias for the author(s) of the API extension // "Sprix"                                                //
+		contents // Table of functions exposed via the API extension  // { HelloWorld = function() print("Hello, World!") end } //
+	[Returns]
+		1 - Token which may be used to securely de-register the APIExtension
+	[Notes]
+		1) Contents table is recursively frozen - plan accordingly!
+		2) Name & Author pair *MUST* be unique
+		3) Will invoke all APIExtensionLoadedCallbacks before returning
+]]
+function publicAPI.AddAPIExtension(name: string, author: string, contents: APIExtension) : string
+	if not ValidateArgTypes("AddAPIExtension", {"name", name, "string"}, {"author", author, "string"}, {"contents", contents, "table"}) then return end
+	return internalAPI.AddAPIExtension(name, author, DeepFreeze(contents))
+end
+
+--[[
+	[Args]
+		 Title // Description                                       // Example       //
+		------ // ------------------------------------------------- // ------------- //
+		  name // Name of the API extension                         // "MyPluginAPI" //
+		author // Name/alias for the author(s) of the API extension // "Sprix"       //
+	[Returns]
+		1 - Table exposed via the API extension, nil if it doesn't exist or has yet to be registered
+	[Notes]
+		1) See AddAPIExtensionLoadedCallback if you need to run code whenever specific extension(s) are loaded 
+]]
+function publicAPI.GetAPIExtension(name: string, author: string) : APIExtension?
+	if not ValidateArgTypes("GetAPIExtension", {"name", name, "string"}, {"author", author, "string"}) then return end
+	return internalAPI.GetAPIExtension(name, author)
+end
+
+--[[
+	[Args]
+		Title // Description                                               //
+		----- // --------------------------------------------------------- //
+		token // Value returned from corresponding call to AddAPIExtension // 
+]]
+function publicAPI.RemoveAPIExtension(token: string)
+	if not ValidateArgTypes("RemoveAPIExtension", {"token", token, "string"}) then return end
+	return internalAPI.RemoveAPIExtension(token)
+end
+
+return table.freeze(publicAPI)

--- a/Plugins/src/SerializationTools/Main.server.lua
+++ b/Plugins/src/SerializationTools/Main.server.lua
@@ -1,7 +1,9 @@
 local toolbar = plugin:CreateToolbar("Mission Exporter")
 local ExportButton = toolbar:CreateButton("Exporter", "Exporter", "rbxassetid://86828934223336")
 
+local Api = require(script.Parent.API.Main)
 local Exporter = require(script.Parent.Writing.Main)
+
 local CurrentPlugin = nil
 
 ExportButton.Click:Connect(function()
@@ -22,5 +24,12 @@ local function disablePlugin()
 	CurrentPlugin = nil
 end
 
-plugin.Unloading:Connect(disablePlugin)
+local function unloadPlugin()
+	Api.Clean()
+	disablePlugin()
+end
+
+plugin.Unloading:Connect(unloadPlugin)
 plugin.Deactivation:Connect(disablePlugin)
+
+Api.Init()

--- a/Plugins/src/SerializationTools/Util/VersionConfig.lua
+++ b/Plugins/src/SerializationTools/Util/VersionConfig.lua
@@ -1,4 +1,5 @@
 return {
 	VersionNumber = 1,
+	VersionNumber_API = 0,
 	ReplaceNewlines = true,
 }


### PR DESCRIPTION
This PR adds a cross plugin scripting API to the Serializer, for use by plugins authored via third parties as well as potential future internal use

This should enable third party authored plugins to register code to run immediately before a map is exported, as well as allow for plugins to expose APIs of their own to third parties using the serializer as a middleman

The hope is that this will allow for the development of significantly more potent third party tools with better end user ergonomics, which may interoperate with one another far easier than previously possible

An example of some tooling this patch enables may be found [here](https://github.com/Sprixitite/InfiltrationEngine-PrefabSystem) - intended as a real-world example of a consumer of the API via the provided utility module (`src/SerializationTools/API/APIConsumer`)

Documentation of the user-facing API may be found in the appropriate file (`src/SerializationTools/API/Public`), anti-tamper measures may be found in `src/SerializationTools/API/Main`, and internal-facing API may be found in `src/SerializationTools/API/Internal`

Minimal changes are made to existing code, only where necessary to enable `PreSerialize` and `SerializerUnloaded` hooks, as well as enable the new "Preprocess Preview" button enabled via creating an `APIDev` attribute on `workspace`

Apologies that this PR is quite as big as it is, I wanted to ensure the resources were as thorough as possible for potential community consumers of the API other than myself on launch of the system

Thanks