### PR TITLE
SerializerAPI // InvokeState Support + PreSerializeMissionSetup Hook

### DIFF
--- a/Plugins/src/SerializationTools/Writing/Main.lua
+++ b/Plugins/src/SerializationTools/Writing/Main.lua
@@ -53,9 +53,8 @@ local function GetMission()
 	local missionClone = mission:Clone()
 	VisibilityToggle.HideTempRevealedParts(mission)
 
-	local oldMissionParent = mission.Parent
-
 	InternalAPI.InvokeHook("PreSerialize", missionClone)
+	InternalAPI.InvokeHook("PreSerializeMissionSetup", missionClone:FindFirstChild("MissionSetup"))
 
 	return missionClone
 end


### PR DESCRIPTION
This adds the feature mentioned in #9 but which did not make that patch - InvokeState

Upon a hook being invoked, the previously `nil` argument which would be passed has now been replaced by a table - the InvokeState - which contains one function as of this commit, the `Get()` function

This function accepts a variable number of arguments which are used to introspect (in a read-only manner for all native Lua datatypes) the state of every other hook that has ran or will run - examples for this may be found in the `API/Public` module in the doc comments for `AddHook`

This allows for plugins to yield until they have detected that another plugin has completed its execution, as well as allowing for sharing of state between hooks from intermediary points in their execution

This patch also includes some small tweaks to the Public and APIConsumer modules where appropriate, with some small QoL functions added to both modules and the type layouts/doc comments updated appropriately

Finally, this patch adds a PreSerializeMissionSetup hook, allowing for easier implementation of tooling which operates on the module

Thanks