### PR TITLE
Serializer // In-Studio Readback Support

### DIFF
--- a/Plugins/src/SerializationTools/Reading/Read.lua
+++ b/Plugins/src/SerializationTools/Reading/Read.lua
@@ -53,6 +53,10 @@ Read = {
 		return string.sub(str, cursor, cursor) == "b", cursor + 1
 	end,
 
+	ShortestInt = function(str, cursor) -- returns the value read as a shortest int. 1 symbol
+		return StringConversion.StringToNumber(str, cursor, 1), cursor + 1
+	end,
+
 	ShortInt = function(str, cursor) -- returns the value read as a short integer. 2 symbols
 		return StringConversion.StringToNumber(str, cursor, 2), cursor + 2
 	end,
@@ -139,6 +143,22 @@ Read = {
 			stringMap[i], cursor = Read.String(str, cursor)
 		end
 		return stringMap, cursor
+	end,
+
+	MissionCodeHeader = function(str, cursor)
+		local codeVersion, mapId, currentCode, totalCodes
+		
+		codeVersion, cursor = Read.ShortestInt(str, cursor)
+		mapId, cursor = Read.ShortInt(str, cursor)
+		currentCode, cursor = Read.ShortInt(str, cursor)
+		totalCodes, cursor = Read.ShortInt(str, cursor)
+		
+		return {
+			CodeVersion = codeVersion,
+			CodeCurrent = currentCode,
+			CodeTotal = totalCodes,
+			MapId = mapId,
+		}, cursor
 	end,
 
 	Mission = function(str, cursor)

--- a/Plugins/src/SerializationTools/Util/FeatureCheck.lua
+++ b/Plugins/src/SerializationTools/Util/FeatureCheck.lua
@@ -1,0 +1,90 @@
+--[[
+	Serializer features may be enabled in one of three ways, from highest-to-lowest priority:
+		The feature-specific attribute (i.e. "ReadDocs")
+		The SerializerFeatures attribute
+		The SerializerEnableAllFeatures attribute
+	
+	Feature-specific attributes may be of any type, with some features expecting specific types
+	
+	The SerializerFeatures attribute is a string of settings, each separated by pipe characters ("|")
+		Settings may either be defined as a flag, or with an explicit string/number/boolean value
+		To give some examples:
+			"ReadDocs|MissionCompression=23" - ReadDocs is a flag, so ReadDocs = true, MissionCompression would return as 23
+			"ReadDocs="Yes, I have read the docs, LET ME MAKE A GIST!!!!""  - Strings work, although maybe don't be so mean to the serializer :(
+			"ReadDocs='Sorry, Mr. Serializer! We love and appreciate you!'" - Both types of quotes are supported
+			"ReadDocs=true|APIDev=false"     - Booleans also work!
+	
+	The SerializerEnableAllFeatures attribute must be a boolean to function, it enables all features that have not had an explicit value set
+]]
+
+-- Cache these, don't want to be parsing the whole thing for every APIDev print - we get boatloads of those if a third party plugin breaks
+local featureCache = setmetatable({}, {__mode='v'})
+local function parseSerializerFeatures()
+	local featStr = workspace:GetAttribute("SerializerFeatures")
+	if featStr == nil then return {} end
+	if type(featStr) ~= "string" then
+		warn("SerializerFeatures attribute on workspace must be a string or nil!")
+		return {}
+	end
+	
+	local existing = featureCache[featStr]
+	if existing then return existing end
+	
+	local featureDict = {}
+	
+	for _, substr in ipairs(string.split(featStr, '|')) do
+		substr = substr:match("^%s*(.-)%s*$")
+
+		local flagged = substr:match("^[^=]+$")
+		if flagged ~= nil then
+			featureDict[flagged] = true
+			continue
+		end
+
+		local feature, value = substr:match("^([^=]+)%s*=%s*([^=]+)$")
+		if feature == nil or value == nil then
+			warn(`SerializerFeature {substr} is invalid! Setting will be ignored.`)
+			continue
+		end
+
+		local valNum = tonumber(value)
+		if valNum ~= nil then 
+			featureDict[feature] = valNum
+			continue
+		end
+
+		local valStr = value:match("^\"(.*)\"$") or value:match("^\'(.*)\'$")
+		if valStr ~= nil then
+			featureDict[feature] = valStr
+			continue
+		end
+
+		value = value:lower()
+		local valBool = value:match("^true$") and true or value:match("^false$") and false
+		if valBool ~= nil then
+			featureDict[feature] = valBool
+			continue
+		end
+		
+		warn(`Specified SerializerFeature "{feature}" was not set to a valid value! Setting will be ignored.`)
+	end
+	
+	featureCache[featStr] = featureDict
+	return featureDict
+end
+
+return function(featureName)
+	local featureValue = workspace:GetAttribute(featureName)
+	if featureValue ~= nil then
+		return featureValue
+	end
+	
+	local featCfg = parseSerializerFeatures()
+	if featCfg[featureName] ~= nil then
+		return featCfg[featureName]
+	end
+	
+	if workspace:GetAttribute("SerializerEnableAllFeatures") == true then
+		return true
+	end
+end

--- a/Plugins/src/SerializationTools/Util/VersionConfig.lua
+++ b/Plugins/src/SerializationTools/Util/VersionConfig.lua
@@ -1,5 +1,34 @@
-return {
-	VersionNumber = 1,
+local VERSION_LATEST = 1
+
+local CODE_VERSION_LOOKUP = {
+	[0] = { ReplaceNewlines = false },
+	[1] = { ReplaceNewlines = true  }
+}
+
+-- This works, Lua counts table lengths starting from 1
+if #CODE_VERSION_LOOKUP > VERSION_LATEST then
+	warn("SerializerDev : Version bumped but no lookup settings defined! Fix before submitting!")
+end
+
+local versionConfig = {
+	LatestVersion = VERSION_LATEST,
+
+	VersionNumber = VERSION_LATEST,
 	VersionNumber_API = 0,
+	
 	ReplaceNewlines = true,
 }
+
+function versionConfig.change_version(self, to)
+	local verSettings = CODE_VERSION_LOOKUP[to]
+	if verSettings == nil then
+		return false, "Code Version " .. tostring(to) .. " is not recognised!"
+	end
+	for k, v in pairs(verSettings) do
+		self[k] = v
+	end
+	self.VersionNumber = to
+	return true, nil
+end
+
+return versionConfig

--- a/Plugins/src/SerializationTools/Writing/Main.lua
+++ b/Plugins/src/SerializationTools/Writing/Main.lua
@@ -10,6 +10,7 @@ local Read = require(script.Parent.Parent.Reading.Read)
 local ReadbackButton = require(script.Parent.ReadbackButton)
 
 local Button = require(script.Parent.Parent.Util.Button)
+local FeatureCheck = require(script.Parent.Parent.Util.FeatureCheck)
 local VisibilityToggle = require(script.Parent.Parent.Util.VisibilityToggle)
 local VersionConfig = require(script.Parent.Parent.Util.VersionConfig)
 
@@ -68,7 +69,7 @@ local function GetMissionCode()
 	return code
 end
 
-local function GetMapId()
+local function GenerateMapId()
 	return math.random(0, StringConversion.GetMaxNumber(2))
 end
 
@@ -77,7 +78,7 @@ module.Init = function(mouse: PluginMouse)
 		return
 	end
 	module.Active = true
-	
+
 	local CodeState = State("")
 	local Pastes = State({})
 
@@ -87,7 +88,7 @@ module.Init = function(mouse: PluginMouse)
 		local current = PASTE_SIZE -- leaving space for paste information
 		local currentPaste = 1
 		local maxPastes = math.ceil(#code / current)
-		local mapId = GetMapId() -- A 2 character integer that can be used to identify maps
+		local mapId = GenerateMapId() -- A 2 character integer that can be used to identify maps
 		while first < #code do
 			local header = Write.MissionCodeHeader(mapId, currentPaste, maxPastes)
 			codeChunks[#codeChunks + 1] = header .. code:sub(first, current)
@@ -98,10 +99,9 @@ module.Init = function(mouse: PluginMouse)
 		return codeChunks
 	end, CodeState)
 
-	local allEnabled 		= workspace:GetAttribute("SerializerEnableAllFeatures")
-	local apiDevEnabled 	= allEnabled or workspace:GetAttribute("APIDev")
-	local gistEnabled 		= allEnabled or workspace:GetAttribute("ReadDocs")
-	local readbackEnabled 	= allEnabled or workspace:GetAttribute("Readback")
+	local apiDevEnabled 	= FeatureCheck("APIDev")   == true
+	local gistEnabled 		= FeatureCheck("ReadDocs") == true
+	local readbackEnabled 	= FeatureCheck("Readback") == true
 
 	module.UI = Create("ScreenGui", {
 		Parent = game:GetService("CoreGui"),
@@ -136,7 +136,7 @@ module.Init = function(mouse: PluginMouse)
 						model.Parent = workspace
 					end
 
-					local output = Write.MissionCodeHeader(GetMapId(), 1, 1)
+					local output = Write.MissionCodeHeader(GenerateMapId(), 1, 1)
 					output = output .. code
 					output = GIST_PREFIX .. output
 

--- a/Plugins/src/SerializationTools/Writing/ReadbackButton.lua
+++ b/Plugins/src/SerializationTools/Writing/ReadbackButton.lua
@@ -1,0 +1,201 @@
+local HttpService = game:GetService("HttpService")
+
+local Read = require(script.Parent.Parent.Reading.Read)
+
+local Actor = require(script.Parent.Parent.Util.Actor)
+local Create = Actor.Create
+local State = Actor.State
+local Derived = Actor.Derived
+
+local function GistLinkToMissionCode(link)
+	link = string.gsub(link, "^%s*(https://gist%.githubusercontent%.com/[^/]+/[^/]+/raw/[^/]+/[%w%.]+)%s*$", function(s) return s end)
+	local creator, fileName = string.match(link, "^%s*https://gist%.githubusercontent%.com/([^/]+)/[^/]+/raw/[^/]+/([%w%.]+)%s*$")
+	if creator == nil or fileName == nil then return false, "Invalid Gist Link" end
+
+	local success, gistCode = pcall(HttpService.GetAsync, HttpService, link)
+	return success, gistCode
+end
+
+local function CreateReadbackBox(enabledState)
+	local readbackState = {}
+	local readStatusState = State({0, 0})
+	local readErrState = State("")
+
+	local function resetReadbackState()
+		readbackState.MapInfo = { CodeVersion = -1 }
+		readbackState.Codes = {}
+		readbackState.Received = {}
+		readStatusState:set({0, 0})
+		readErrState:set("")
+	end
+	resetReadbackState()
+
+	local codeInput = Create(
+		"TextBox",
+		{
+			Size = UDim2.new(1, -30, 0.5, 0),
+			Enabled = enabledState,
+			Position = UDim2.new(0, 0, 0, 0),
+			Text = "",
+			TextTruncate = Enum.TextTruncate.AtEnd,
+			PlaceholderText = "Input Code",
+			TextColor3 = Color3.new(255, 255, 255),
+			BackgroundColor3 = Color3.new(0, 0, 0),
+			BackgroundTransparency = 0.5,
+			BorderSizePixel = 0,
+			TextSize = 20,
+			Font = Enum.Font.SciFi,
+		}
+	)
+
+	codeInput.FocusLost:Connect(function(enterPressed, _)
+		if not enterPressed then return end
+		local inputText = codeInput.Text
+		if codeInput.Text:match("^https://") ~= nil then
+			local success, missionCode = GistLinkToMissionCode(inputText)
+			if not success then
+				readErrState:set(missionCode)
+				return
+			end
+			inputText = missionCode
+		end
+
+		local inputNoComment = inputText
+		if inputText:match("^!!!") ~= nil then
+			inputNoComment = inputText:match("!!!.-!!!(.+)")
+			if inputNoComment == nil then
+				readErrState:set("Invalid Opening Comment")
+				return
+			end
+		end
+		
+		local inputHeader, cursor = Read.MissionCodeHeader(inputNoComment, 1)
+		local inputContent = string.sub(inputNoComment, cursor)
+
+		local existingMapInfo = readbackState.MapInfo
+		if existingMapInfo.CodeVersion == -1 then
+			readbackState.MapInfo.CodeVersion = inputHeader.CodeVersion
+			readbackState.MapInfo.CodeTotal = inputHeader.CodeTotal
+			readbackState.MapInfo.MapId = inputHeader.MapId
+		end
+
+		if existingMapInfo.CodeVersion ~= inputHeader.CodeVersion then
+			readErrState:set("Code Version Mismatch")
+			return
+		elseif existingMapInfo.MapId ~= inputHeader.MapId then
+			readErrState:set("Map ID Mismatch")
+			return
+		elseif existingMapInfo.CodeTotal ~= inputHeader.CodeTotal then
+			readErrState:set("Code Count Mismatch")
+			return
+		end
+
+		readbackState.Codes[inputHeader.CodeCurrent] = inputContent
+		readbackState.Received[inputHeader.CodeCurrent] = true
+		readErrState:set("")
+		codeInput.Text = ""
+
+		local allReceived = true
+		local receivedCount = 0
+		for i=1, readbackState.MapInfo.CodeTotal do
+			if readbackState.Received[i] then receivedCount = receivedCount + 1 end
+			allReceived = allReceived and readbackState.Received[i]
+		end
+		
+		readStatusState:set({ receivedCount, readbackState.MapInfo.CodeTotal })
+
+		if not allReceived then return end
+		local finalCode = ""
+		for codePart, codeContent in ipairs(readbackState.Codes) do
+			finalCode = finalCode .. codeContent
+		end
+
+		local mission = Read.Mission(finalCode, 1)
+		mission.Parent = workspace
+		resetReadbackState()
+	end)
+
+	local resetState = Create(
+		"ImageButton",
+		{
+			Image = "rbxassetid://89515271880693",
+			Size = UDim2.new(0, 30, .5, 0),
+			Enabled = enabledState,
+			Position = UDim2.new(1, -30, 0, 0),
+			BackgroundTransparency = 0.5,
+			BackgroundColor3 = Color3.new(0, 0, 0),
+			BorderSizePixel = 0,
+			Activated = function()
+				codeInput:ReleaseFocus()
+				codeInput.Text = ""
+				readErrState:set("")
+				resetReadbackState()
+			end,
+		}
+	)
+
+	local errLabel = Create(
+		"TextLabel",
+		{
+			Size = UDim2.new(1, 0, 0.5, 0),
+			Enabled = enabledState,
+			Position = UDim2.new(0, 0, 0.5, 0),
+			TextColor3 = Color3.fromRGB(209, 77, 79),
+			BackgroundTransparency = 0.5,
+			BackgroundColor3 = Color3.new(0, 0, 0),
+			BorderSizePixel = 0,
+			TextSize = 20,
+			TextScaled = true,
+			Font = Enum.Font.SciFi,
+			Text = Derived(function(errmsg)
+				return errmsg
+			end, readErrState),
+			Visible = Derived(function(errmsg)
+				return #errmsg ~= 0
+			end, readErrState)
+		}
+	)
+	
+	local statusLabel = Create(
+		"TextLabel",
+		{
+			Size = UDim2.new(1, 0, 0.5, 0),
+			Enabled = enabledState,
+			Position = UDim2.new(0, 0, 0.5, 0),
+			TextColor3 = Color3.new(1, 1, 1),
+			BackgroundTransparency = 0.5,
+			BackgroundColor3 = Color3.new(0, 0, 0),
+			BorderSizePixel = 0,
+			TextSize = 20,
+			Font = Enum.Font.SciFi,
+			Text = Derived(function(tbl)
+				return "Import Status: " .. tostring(tbl[1]) .. '/' .. tostring(tbl[2])
+			end, readStatusState),
+			Visible = Derived(function(tbl, errmsg)
+				if #errmsg ~= 0 then return false end
+				return tbl[1] ~= tbl[2]
+			end, readStatusState, readErrState)
+		}
+	)
+
+	local readPanel = Create(
+		"Frame",
+		{
+			Size = UDim2.new(0, 200, 0, 60),
+			Enabled = enabledState,
+			Position = UDim2.new(1, -50, 0, 50),
+			AnchorPoint = Vector2.new(1, 0),
+			BackgroundTransparency = 1,
+		},
+		{
+			codeInput,
+			resetState,
+			errLabel,
+			statusLabel
+		}
+	)
+
+	return readPanel
+end
+
+return CreateReadbackBox

--- a/Plugins/src/SerializationTools/Writing/Write.lua
+++ b/Plugins/src/SerializationTools/Writing/Write.lua
@@ -39,6 +39,11 @@ Write = {
 		return if bool then "b" else "c"
 	end,
 
+	ShortestInt = function(num) -- 1 character
+		num = math.clamp(num, 0, SHORTEST_INT_BOUND)
+		return StringConversion.NumberToString(num, 1)
+	end,
+
 	ShortInt = function(num) -- 2 characters
 		if num > SHORT_INT_BOUND then
 			return StringConversion.NumberToString(SHORT_INT_BOUND, 2)
@@ -61,7 +66,7 @@ Write = {
 		end
 	end,
 
-	LongInt = function(num)
+	LongInt = function(num) -- 6 characters
 		if num > LONG_INT_BOUND then
 			warn("Int out of bounds range:", num)
 			return StringConversion.NumberToString(LONG_INT_BOUND, 6)
@@ -151,6 +156,14 @@ Write = {
 		return Write.ShortInt(#stringMap) .. stringStr
 	end,
 
+	MissionCodeHeader = function(mapId, current, total)
+		local header = Write.ShortestInt(VersionConfig.VersionNumber)
+		header = header .. Write.ShortInt(mapId)
+		header = header .. Write.ShortInt(current)
+		header = header .. Write.ShortInt(total)
+		return header
+	end,
+
 	Mission = function(mission)
 		local str = ""
 
@@ -219,8 +232,8 @@ Write = {
 				childrenProperties = childrenProperties .. Write.Instance(v, colorMap, stringMap)
 			end
 			return instanceType .. objectProperties .. childrenProperties .. StringConversion.NumberToString(0, 1),
-				colorMap,
-				stringMap
+			colorMap,
+			stringMap
 		else
 			return StringConversion.NumberToString(InstanceTypes.Nil, 1), colorMap, stringMap
 		end


### PR DESCRIPTION
Adds support for readback of missions in studio, both in gist and standard code forms - this is locked behind the `Readback` attribute being set to true on workspace

This patch also introduces the `SerializerEnableAllFeatures` attribute, which should enable `ReadDocs`, `APIDev`, `Readback`, and any potential future features with just the one flag