### PR TITLE
Serializer // Attribute validation bypassing

### DIFF
--- a/Plugins/src/SerializationTools/AttributeValidation.lua
+++ b/Plugins/src/SerializationTools/AttributeValidation.lua
@@ -241,7 +241,10 @@ return {
 			return attributes
 		end
 
-		if attributes.Type == "StateScript" or instanceName == "StateScriptPart" then
+		if attributes.IKnowWhatImDoingDoNotValidate == true then
+			warn(`Instance {instanceName} of Class {className} is intentionally opting out of attribute validation`)
+			return attributes
+		elseif attributes.Type == "StateScript" or instanceName == "StateScriptPart" then
 			return attributes
 		end
 


### PR DESCRIPTION
Simple four line change, adds the ability to deliberately bypass attribute validation by setting the `IKnowWhatImDoingDoNotValidate` attribute to `true`

When respected this attribute will emit an appropriate warning