### PR TITLE
API // Support for yielding in hooks via new coroutine-commands

### DIFF
--- a/Plugins/src/SerializationTools/API/Public.lua
+++ b/Plugins/src/SerializationTools/API/Public.lua
@@ -1,5 +1,3 @@
-local httpService = game:GetService("HttpService")
-
 local attributesMap = require(script.Parent.Parent.AttributesMap)
 local attributeTypes = require(script.Parent.Parent.PropAttributeTypes)
 local versionCfg = require(script.Parent.Parent.Util.VersionConfig)
@@ -78,6 +76,22 @@ end
 
 --[[
 	[Args]
+		 Title // Description                                  // Example             //
+		------ // -------------------------------------------- // ------------------- //
+		thread // The thread to compare against the API thread // coroutine.running() //
+	[Returns]
+		1 - If the threads are the same
+]]
+function publicAPI.IsAPIThread(thread: thread) : boolean
+	if not ValidateArgTypes(
+		"IsAPIThread",
+		{ "thread", thread, "thread" }
+		) then return false end
+	return thread == internalAPI.RunningThread
+end
+
+--[[
+	[Args]
 		 Title // Description                                        // Example    //
 		------ // -------------------------------------------------- // ---------- //
 		author // Name/alias for the author(s) of the calling plugin // "Sprix"    //
@@ -86,6 +100,11 @@ end
 		1 - Helper function which constructs registrant names
 ]]
 function publicAPI.GetRegistrantFactory(author: string, plugin: string) : (string) -> string
+	if not ValidateArgTypes(
+		"GetRegistrantFactory",
+		{ "author", author, "string" },
+		{ "plugin", plugin, "string" }
+		) then return nil end
 	local prefix = author .. '_' .. plugin
 	return function(hookName) return prefix .. '_' .. hookName end
 end
@@ -116,7 +135,7 @@ end
 	[Args]
 		     Title // Description                                                                       // Example                                   //
 		---------- // --------------------------------------------------------------------------------- // ----------------------------------------- //
-		  hookType // String corresponding to the type of hook being removed                            // "PreSerialize"                            //
+		  hookType // String corresponding to the type of hook being added                              // "PreSerialize"                            //
 		registrant // String representing the source of the hook. Should be unique                      // "MyPlugin"                                //
 		      hook // Function to be invoked when the corresponding hookType is invoked                 // function() print("Hook!") end             //
 		 hookState // (Optional) Extra state to be passed as the last argument to the hook when invoked // { PartCol = Color3.fromHex("#FFFFFF") }   //

--- a/Plugins/src/SerializationTools/Main.server.lua
+++ b/Plugins/src/SerializationTools/Main.server.lua
@@ -1,8 +1,17 @@
+local runService = game:GetService("RunService")
+
 local toolbar = plugin:CreateToolbar("Mission Exporter")
 local ExportButton = toolbar:CreateButton("Exporter", "Exporter", "rbxassetid://86828934223336")
 
-local Api = require(script.Parent.API.Main)
 local Exporter = require(script.Parent.Writing.Main)
+
+-- Should silence morgan's studio warnings about anti-tamper
+local Api
+if runService:IsStudio() and not runService:IsRunMode() then
+	Api = require("./API/Main")
+else
+	Api = { Clean = function() end, Init = function() end }
+end
 
 local CurrentPlugin = nil
 

--- a/Plugins/src/SerializationTools/Util/VersionConfig.lua
+++ b/Plugins/src/SerializationTools/Util/VersionConfig.lua
@@ -14,7 +14,7 @@ local versionConfig = {
 	LatestVersion = VERSION_LATEST,
 
 	VersionNumber = VERSION_LATEST,
-	VersionNumber_API = 0,
+	VersionNumber_API = 1,
 	
 	ReplaceNewlines = true,
 }


### PR DESCRIPTION
This patch adds the ability for API hooks to yield by issuing a command to the serializer like so:
`coroutine.yield("CMD_WAIT", durationSeconds)`

This is necessary because of an implementation detail I was previously unaware of with respect to yielding in coroutines, wherein any form of yield (`wait`, `task.wait`, `RBXScriptSignal:Wait()`, etc.) is treated as a call to `coroutine.yield()` by the task scheduler

Furthermore, this patch bundles a small fix which disables the API when not run in non-play mode studio, as well as some small ergonomics improvements to APIConsumer (and an attempted bugfix for handling of hot-swapping serializers, still need to investigate some warnings in a future patch)

<sub>Sorry about the delay on the compression patch, the rebase went a little wonky and I've been too preoccupied with other things to take the time to go in and sort it out, this patch was thrown together in response to suddenly encountering this unexpected behaviour and needing it resolved ASAP</sub>

Thanks