### PR TITLE
perf: Optimize Serialization & Terrain Export

### DIFF
--- a/Plugins/src/InfiltrationEngineTools/Main.server.lua
+++ b/Plugins/src/InfiltrationEngineTools/Main.server.lua
@@ -71,5 +71,5 @@ local function disablePlugin()
 	CurrentPlugin = nil
 end
 
-plugin.Unloading:connect(disablePlugin)
-plugin.Deactivation:connect(disablePlugin)
+plugin.Unloading:Connect(disablePlugin)
+plugin.Deactivation:Connect(disablePlugin)

--- a/Plugins/src/InfiltrationEngineTools/TerrainSerialization/TerrainSerialization.lua
+++ b/Plugins/src/InfiltrationEngineTools/TerrainSerialization/TerrainSerialization.lua
@@ -90,13 +90,17 @@ local module = {
 		local values = {}
 		local lastValue = channel[1][1][1]
 		local sequenceLength = 0
+		local insertIndex = 1
 		for x = 1, BLOCK_SIZE do
+			local cx = channel[x]
 			for y = 1, BLOCK_SIZE do
+				local cxy = cx[y]
 				for z = 1, BLOCK_SIZE do
-					local value = channel[x][y][z]
+					local value = cxy[z]
 					if value ~= lastValue or sequenceLength == BUFFER_RANGE then
-						table.insert(counts, sequenceLength)
-						table.insert(values, lastValue)
+						counts[insertIndex] = sequenceLength
+						values[insertIndex] = lastValue
+						insertIndex += 1
 						lastValue = value
 						sequenceLength = 0
 					end
@@ -105,12 +109,12 @@ local module = {
 			end
 		end
 
-		table.insert(counts, sequenceLength)
-		table.insert(values, lastValue)
+		counts[insertIndex] = sequenceLength
+		values[insertIndex] = lastValue
 
-		local channelBuffer = buffer.create(#counts * 2)
-		for index, count in counts do
-			buffer.writeu8(channelBuffer, index * 2 - 2, count + BUFFER_OFFSET)
+		local channelBuffer = buffer.create(insertIndex * 2)
+		for index = 1, insertIndex do
+			buffer.writeu8(channelBuffer, index * 2 - 2, counts[index] + BUFFER_OFFSET)
 			buffer.writeu8(channelBuffer, index * 2 - 1, values[index] + BUFFER_OFFSET)
 		end
 
@@ -127,9 +131,11 @@ local module = {
 
 		local channel = {}
 		for x = 1, BLOCK_SIZE do
-			channel[x] = {}
+			local cx = {}
+			channel[x] = cx
 			for y = 1, BLOCK_SIZE do
-				channel[x][y] = {}
+				local cxy = {}
+				cx[y] = cxy
 				for z = 1, BLOCK_SIZE do
 					if applyCount <= 0 and readIndex < bufferLen then
 						applyCount = buffer.readu8(channelBuffer, readIndex) - BUFFER_OFFSET
@@ -137,7 +143,7 @@ local module = {
 						readIndex += 2
 					end
 					applyCount -= 1
-					channel[x][y][z] = applyValue
+					cxy[z] = applyValue
 				end
 			end
 		end
@@ -146,9 +152,11 @@ local module = {
 	end,
 	TransformChannel = function(self, channel, modify)
 		for x = 1, BLOCK_SIZE do
+			local cx = channel[x]
 			for y = 1, BLOCK_SIZE do
+				local cxy = cx[y]
 				for z = 1, BLOCK_SIZE do
-					channel[x][y][z] = modify(channel[x][y][z])
+					cxy[z] = modify(cxy[z])
 				end
 			end
 		end

--- a/Plugins/src/SerializationTools/AttributeValidation.lua
+++ b/Plugins/src/SerializationTools/AttributeValidation.lua
@@ -36,6 +36,11 @@ local GlobalPropAttributes = {
 	BreakAlarm = { PropAttributeTypes.STRING, nil },
 }
 
+local reverseAttributeTypes = {}
+for i, v in pairs(PropAttributeTypes) do
+	reverseAttributeTypes[v] = i
+end
+
 local testAttributeCompatibility = function(attributeType, value, objectName, attributeName)
 	if attributeType == "NUMBER" then
 		if type(value) == "number" then
@@ -266,12 +271,7 @@ return {
 					continue
 				end
 				local givenValue = attributes[attName]
-				local attributeTypeName = ""
-				for i, v in pairs(PropAttributeTypes) do
-					if tableOfInfo[1] == v then
-						attributeTypeName = i
-					end
-				end
+				local attributeTypeName = reverseAttributeTypes[tableOfInfo[1]] or ""
 				if attributeTypeName == "" then
 					error(`attribute type does not exist: {name} {attName}`)
 				end
@@ -290,12 +290,7 @@ return {
 			for attribute, value in pairs(attributes) do -- add the remaining attributes that are defined in the global attributes table above
 				if GlobalPropAttributes[attribute] then
 					local tableOfInfo = GlobalPropAttributes[attribute]
-					local attributeTypeName = ""
-					for i, v in pairs(PropAttributeTypes) do
-						if tableOfInfo[1] == v then
-							attributeTypeName = i
-						end
-					end
+					local attributeTypeName = reverseAttributeTypes[tableOfInfo[1]] or ""
 					if testAttributeCompatibility(attributeTypeName, value, name, attribute) then
 						newAttributes[attribute] = value
 					else

--- a/Plugins/src/SerializationTools/Reading/Read.lua
+++ b/Plugins/src/SerializationTools/Reading/Read.lua
@@ -14,6 +14,8 @@ local SHORT_BOUNDED_FLOAT_BOUND = StringConversion.GetMaxNumber(2)
 local Root
 local Read
 
+local childrenCache = {}
+
 local denormalize = function(value)
 	return value * (2 * math.pi) - math.pi
 end
@@ -50,7 +52,12 @@ local function ResolvePath(root, pathString)
 
 	for index in string.gmatch(pathString, "%d+") do
 		index = tonumber(index)
-		current = current:GetChildren()[index]
+		local children = childrenCache[current]
+		if not children then
+			children = current:GetChildren()
+			childrenCache[current] = children
+		end
+		current = children[index]
 
 		if not current then
 			return nil

--- a/Plugins/src/SerializationTools/StringConversion.lua
+++ b/Plugins/src/SerializationTools/StringConversion.lua
@@ -93,15 +93,13 @@ return {
 	end,
 
 	NumberToString = function(number, charCount)
-		local str = ""
-		local iteration = 0
-		while number >= 0 and iteration < charCount do
+		local buf = table.create(charCount)
+		for i = charCount, 1, -1 do
 			local value = number % CHAR_COUNT
-			str = characterValues[value] .. str
+			buf[i] = characterValues[value]
 			number = math.floor(number / CHAR_COUNT)
-			iteration += 1
 		end
-		return str
+		return table.concat(buf)
 	end,
 
 	GetMaxNumber = function(charCount)

--- a/Plugins/src/SerializationTools/Writing/ReadbackButton.lua
+++ b/Plugins/src/SerializationTools/Writing/ReadbackButton.lua
@@ -155,10 +155,7 @@ local function createReadbackBox(enabledState)
 		readStatusState:set({ receivedCount, readbackState.MapInfo.CodeTotal })
 
 		if not allReceived then return end
-		local finalCode = ""
-		for codePart, codeContent in ipairs(readbackState.Codes) do
-			finalCode = finalCode .. codeContent
-		end
+		local finalCode = table.concat(readbackState.Codes)
 		
 		local success, errReason = VersionConfig:change_version(readbackState.MapInfo.CodeVersion)
 		if not success then

--- a/Plugins/src/SerializationTools/Writing/Write.lua
+++ b/Plugins/src/SerializationTools/Writing/Write.lua
@@ -27,20 +27,26 @@ local function CreateEnumWriter(keys)
 	end
 end
 
+local IndexCache = {}
+
 local function GetIndex(object)
-	local parent = object.Parent
-	local children = parent:GetChildren()
+	if IndexCache[object] then
+		return IndexCache[object]
+	end
 	
+	local parent = object.Parent
+	if not parent then return 1 end
+
+	local children = parent:GetChildren()
 	local index = 1
 	for _, child in children do
-		if child == object then
-			return index
-		elseif WriteInstance[child.ClassName] then -- Ignore unserialized instances
+		if WriteInstance[child.ClassName] then -- Ignore unserialized instances
+			IndexCache[child] = index
 			index += 1
 		end
 	end
 	
-	return index
+	return IndexCache[object] or 1
 end
 
 local ESCAPED_NEWLINES_ACTIVE = VersionConfig.ReplaceNewlines
@@ -113,11 +119,13 @@ Write = {
 
 	FloatSequence = function (numberSequence) -- 2 + 7 * keypoints characters
 		local keypoints = numberSequence.Keypoints
-		local numberSequenceStr = Write.ShortInt(#keypoints)
+		local sequenceBuffer = { Write.ShortInt(#keypoints) }
 		for i, v in pairs(keypoints) do
-			numberSequenceStr = numberSequenceStr .. Write.ShortBoundedFloat(v.Time) .. Write.Float(v.Value) .. Write.Float(v.Envelope)
+			table.insert(sequenceBuffer, Write.ShortBoundedFloat(v.Time))
+			table.insert(sequenceBuffer, Write.Float(v.Value))
+			table.insert(sequenceBuffer, Write.Float(v.Envelope))
 		end
-		return numberSequenceStr
+		return table.concat(sequenceBuffer)
 	end,
 
 	Vector2 = function(vector) -- 10 characters, 5 for each float XY
@@ -172,11 +180,12 @@ Write = {
 
 	ColorSequence = function (colorSequence) -- 2 + 8 * keypoints characters
 		local keypoints = colorSequence.Keypoints
-		local colorSequenceStr = Write.ShortInt(#keypoints)
+		local sequenceBuffer = { Write.ShortInt(#keypoints) }
 		for i, v in pairs(keypoints) do
-			colorSequenceStr = colorSequenceStr .. Write.ShortBoundedFloat(v.Time) .. Write.Color3(v.Value)
+			table.insert(sequenceBuffer, Write.ShortBoundedFloat(v.Time))
+			table.insert(sequenceBuffer, Write.Color3(v.Value))
 		end
-		return colorSequenceStr
+		return table.concat(sequenceBuffer)
 	end,
 
 	String = function(str) -- 4 + length characters
@@ -205,24 +214,24 @@ Write = {
 		end
 		
 		-- Concat
-		path = table.concat(path, `.`)
-		return Write.Int(#path) .. path
+		local pathStr = table.concat(path, `.`)
+		return Write.Int(#pathStr) .. pathStr
 	end,
 
 	ColorMap = function(colorMap)
-		local colorStr = ""
+		local mapBuffer = {}
 		for i, v in pairs(colorMap) do
-			colorStr = colorStr .. Write.Color3(v)
+			table.insert(mapBuffer, Write.Color3(v))
 		end
-		return Write.ShortInt(#colorMap) .. colorStr
+		return Write.ShortInt(#colorMap) .. table.concat(mapBuffer)
 	end,
 
 	StringMap = function(stringMap)
-		local stringStr = ""
+		local mapBuffer = {}
 		for i, v in pairs(stringMap) do
-			stringStr = stringStr .. Write.String(v)
+			table.insert(mapBuffer, Write.String(v))
 		end
-		return Write.ShortInt(#stringMap) .. stringStr
+		return Write.ShortInt(#stringMap) .. table.concat(mapBuffer)
 	end,
 
 	MissionCodeHeader = function(mapId, current, total)
@@ -234,7 +243,8 @@ Write = {
 	end,
 
 	Mission = function(mission)
-		local str = ""
+		local str
+		table.clear(IndexCache)
 
 		local MissionSetup = require(mission:FindFirstChild("MissionSetup"):Clone())
 
@@ -278,8 +288,8 @@ Write = {
 			colorMapArr[colidx] = Color3.fromHex(colHex)
 		end
 
-		for str, stridx in pairs(stringMap) do
-			stringMapArr[stridx] = str
+		for stringValue, stridx in pairs(stringMap) do
+			stringMapArr[stridx] = stringValue
 		end
 
 		local colorMapStr = Write.ColorMap(colorMapArr)
@@ -288,23 +298,39 @@ Write = {
 		return colorMapStr .. stringMapStr .. str
 	end,
 
-	Instance = function(object, colorMap, stringMap)
+	Instance = function(object, colorMap, stringMap, buffer)
+		local returnStr = false
+		if buffer == nil then
+			buffer = {}
+			returnStr = true
+		end
+
 		local className = object.ClassName
 		if InstanceTypes[object.ClassName] ~= nil then
 			if next(object:GetAttributes()) == nil and object.ClassName == "Part" then
 				className = className .. "NoAttributes"
 			end
 			local instanceType = StringConversion.NumberToString(InstanceTypes[className], 1)
-			local objectProperties, colorMap, stringMap = WriteInstance[className](object, Write, colorMap, stringMap)
-			local childrenProperties = ""
+			table.insert(buffer, instanceType)
+			
+			colorMap, stringMap = WriteInstance[className](object, Write, colorMap, stringMap, buffer)
 			for i, v in pairs(object:GetChildren()) do
-				childrenProperties = childrenProperties .. Write.Instance(v, colorMap, stringMap)
+				colorMap, stringMap = Write.Instance(v, colorMap, stringMap, buffer)
 			end
-			return instanceType .. objectProperties .. childrenProperties .. StringConversion.NumberToString(0, 1),
-			colorMap,
-			stringMap
+			table.insert(buffer, StringConversion.NumberToString(0, 1))
+			
+			if returnStr then
+				return table.concat(buffer), colorMap, stringMap
+			else
+				return colorMap, stringMap
+			end
 		else
-			return StringConversion.NumberToString(InstanceTypes.Nil, 1), colorMap, stringMap
+			table.insert(buffer, StringConversion.NumberToString(InstanceTypes.Nil, 1))
+			if returnStr then
+				return table.concat(buffer), colorMap, stringMap
+			else
+				return colorMap, stringMap
+			end
 		end
 	end,
 

--- a/Plugins/src/SerializationTools/Writing/WriteInstance.lua
+++ b/Plugins/src/SerializationTools/Writing/WriteInstance.lua
@@ -20,11 +20,10 @@ local function lookupMapIndex(map, value)
 end
 
 local WithAttributes = function(DefaultWriter)
-	return function(object, Write, colorMap, stringMap)
-		local str = DefaultWriter(object, Write, colorMap, stringMap)
+	return function(object, Write, colorMap, stringMap, buffer)
+		colorMap, stringMap = DefaultWriter(object, Write, colorMap, stringMap, buffer)
 		local attributes = object:GetAttributes()
 		attributes = AttributeValidation.Validate(object.ClassName, object.Name, attributes, false)
-		local attString = ""
 
 		-- Encoding Attributes
 		for k, v in pairs(attributes) do
@@ -48,28 +47,25 @@ local WithAttributes = function(DefaultWriter)
 			end
 
 			local index = lookupMapIndex(stringMap, k)
-			attString = attString
-				.. StringConversion.NumberToString(AttributeTypes[attributeType], 1)
-				.. Write.ShortInt(index)
+			table.insert(buffer, StringConversion.NumberToString(AttributeTypes[attributeType], 1) .. Write.ShortInt(index))
 
 			if attributeType == "Color3" then
 				local index = lookupMapIndex(colorMap, v)
-				attString = attString .. Write.ShortInt(index)
+				table.insert(buffer, Write.ShortInt(index))
 			elseif attributeType == "String" then
 				local index = lookupMapIndex(stringMap, v)
-				attString = attString .. Write.ShortInt(index)
+				table.insert(buffer, Write.ShortInt(index))
 			else
-				attString = attString .. Write[attributeType](v)
+				table.insert(buffer, Write[attributeType](v))
 			end
 		end
-		str = str .. attString .. StringConversion.NumberToString(0, 1)
-		return str, colorMap, stringMap
+		table.insert(buffer, StringConversion.NumberToString(0, 1))
+		return colorMap, stringMap
 	end
 end
 
 local CreateInstanceWriter = function(properties)
-	local WriteInstance = function(object, Write, colorMap, stringMap)
-		local str = ""
+	local WriteInstance = function(object, Write, colorMap, stringMap, buffer)
 		for i, v in pairs(properties) do
 			local value
 			if v[1] == "MeshId" and object.ClassName == "UnionOperation" then
@@ -81,22 +77,19 @@ local CreateInstanceWriter = function(properties)
 			local defaultValue = v[3]
 			if (valueType == "Color3") and (value ~= defaultValue) then
 				local index = lookupMapIndex(colorMap, value)
-				str = str .. StringConversion.NumberToString(i, 1)
-				str = str .. Write.ShortInt(index)
+				table.insert(buffer, StringConversion.NumberToString(i, 1) .. Write.ShortInt(index))
 				continue
 			elseif (valueType == "String") and (value ~= defaultValue) then
 				local index = lookupMapIndex(stringMap, value)
-				str = str .. StringConversion.NumberToString(i, 1)
-				str = str .. Write.ShortInt(index)
+				table.insert(buffer, StringConversion.NumberToString(i, 1) .. Write.ShortInt(index))
 				continue
 			elseif value ~= defaultValue then
-				str = str .. StringConversion.NumberToString(i, 1)
-				str = str .. Write[valueType](value)
+				table.insert(buffer, StringConversion.NumberToString(i, 1) .. Write[valueType](value))
 			end
 		end
 
-		str = str .. StringConversion.NumberToString(0, 1)
-		return str, colorMap, stringMap
+		table.insert(buffer, StringConversion.NumberToString(0, 1))
+		return colorMap, stringMap
 	end
 	return WriteInstance
 end


### PR DESCRIPTION
> _Note: The term performance is used across this description but it doesn't hint towards tooling running "noticeably faster". There are factors out of our control that bottleneck how fast the tooling can be_

This PR improves the overall performance of the mission exporter and terrain serialization tools. Concatenation with strings across the exporter are now replaced with table buffers and the usage of `table.concat()`, reducing redundant memory allocations, therefore improving performance. Along with the following, instance reference paths are now memoized to prevent repeated sibling scans, and inner voxel loops in terrain serialization are tightened replacing `table.insert()` with direct index assignment.

No behavior changes involved, output is identical.

List of the commits & their descriptions:

- Write.lua: Most functions involving string concatenation now use table buffers with `table.concat()`
- Write.lua (GetIndex): Introduce `IndexCache` to memoize sibling indices, reducing resolution from O(N) to O(1) after first traversal
- WriteInstance.lua: Use a shared buffer to avoid per-property string allocations
- ReadbackButton.lua: Replace code chunk concatenation loop with `table.concat()`
- TerrainSerialization.lua: Cache channel sub-tables (`cx`, `cxy`) to prevent repeated traversals; replace `table.insert()` calls in `CompressChannel()` with numeric index assignment

And I added four more optimizations:

- StringConversion.lua: Replace character prepend loop in `NumberToString()` with reverse-indexed table + `table.concat()`
- AttributeValidation.lua: Performing a linear scan of `PropAttributeTypes` for every attribute with validated instance, instead pre-built a `reverseAttributeTypes` table during module load, replacing both scans with O(1) lookup.
- Read.lua (ResolvePath): `GetChildren()` was called multiple times on the same parent every time an inst. reference was resolved during import. Now added a `childrenCache` so each parent's children list is only fetched once.
- Main.server.lua: Fixed deprecated `:connect()`, _very minor change_

Simple change, big effect

Wind