### PR TITLE
Serializer // Notifications

### DIFF
--- a/Plugins/src/SerializationTools/API/APIConsumer.lua
+++ b/Plugins/src/SerializationTools/API/APIConsumer.lua
@@ -15,6 +15,9 @@ export type Hook = (...any) -> nil
 export type HookType = "APIExtensionLoaded"|"APIExtensionUnloaded"|"PreSerialize"|"PreSerializeMissionSetup"|"SerializerUnloaded"
 export type APIExtension = { [string] : (...any) -> ...any }
 
+export type APINotifSev  = "MIN"|"INFO"|"WARN"|"ERR"|"ERR_SEVERE"|"MAX"|number
+export type APINotifData = { Title: string, Description: string, Severity: APINotifSev, Rich: boolean? }
+
 export type APIReference = {
 	-- Generic
 	GetAPIVersion 			: () -> number,
@@ -22,7 +25,8 @@ export type APIReference = {
 	GetAttributesMap 		: () -> { [string] : { [number] : any } },
 	GetAttributeTypes 		: () -> { [string] : number },
 	IsAPIThread				: (thread) -> boolean,
-	GetRegistrantFactory	: (author: string, plugin: string) -> ((hookName: string) -> string), 
+	GetRegistrantFactory	: (author: string, plugin: string) -> ((hookName: string) -> string),
+	PushNotification		: (notif_data: APINotifData) -> boolean?,
 
 	-- HookTypes
 	GetHookTypes 			: () -> { [number] : string },

--- a/Plugins/src/SerializationTools/API/Internal.lua
+++ b/Plugins/src/SerializationTools/API/Internal.lua
@@ -3,6 +3,8 @@ local httpService = game:GetService("HttpService")
 local attributesMap = require(script.Parent.Parent.AttributesMap)
 local featureCheck = require(script.Parent.Parent.Util.FeatureCheck)
 
+local notifMan = require(script.Parent.Parent.Util.Notifications.Manager)
+
 local internalAPI = {}
 internalAPI.APIExtensions = {}
 
@@ -20,6 +22,14 @@ internalAPI.ProtectedStateKeys = {
 	Present = true,
 	Done = false
 }
+
+local function truncateString(str, to)
+	if #str > to then
+		return str:sub(1, to) .. "..."
+	else
+		return str
+	end
+end
 
 local wait_event = Instance.new("BindableEvent")
 internalAPI.StateCommands = {
@@ -217,7 +227,7 @@ internalAPI.InvokeHook = function(hookType, ...)
 			local success, stateOut, arg1 = co_xpcall(hookCoroutine, arg_merge(unpack(hook.CMD_Result), hook.CallbackState, invokeStatePublic, ...))
 			internalAPI.RunningThread = nil
 
-			if type(stateOut) == "string" then
+			if success and type(stateOut) == "string" then
 				stateOut = stateOut:upper()
 			else
 				hook.CMD_Result = {}
@@ -246,7 +256,13 @@ internalAPI.InvokeHook = function(hookType, ...)
 			elseif success and coroutine.status(hookCoroutine) == "dead" then
 				invokeState[hook.Registrant].Done = true
 			elseif not success then
-				warn(`Error encountered when running {hookType}Hook {hook.Registrant} - {stateVals}`)
+				warn(`Error encountered when running {hookType}Hook {hook.Registrant} - {stateOut}`)
+				notifMan.Push{
+					Title = `Plugin Error ({truncateString(hook.Registrant, 16)})`,
+					Description = `{hookType}Hook {hook.Registrant} experienced an error. Check the Script Output window for details.\n\n` .. 
+								  `MiniError:\n{truncateString(stateOut, 32)}`,
+					Severity = "WARN"
+				}
 			end
 		end
 
@@ -258,6 +274,12 @@ internalAPI.InvokeHook = function(hookType, ...)
 		for _, hook in ipairs(unfinishedHooks) do
 			warn(`\t{hook.Registrant}`)
 		end
+		notifMan.Push{
+			Title = "Plugin Error",
+			Description = `{#unfinishedHooks} {hookType}Hook plugins failed to finish execution!\n` .. 
+						  "Please check your Script Output window.",
+			Severity = "WARN"
+		}
 	end
 
 end

--- a/Plugins/src/SerializationTools/API/Public.lua
+++ b/Plugins/src/SerializationTools/API/Public.lua
@@ -1,8 +1,13 @@
+local httpService = game:GetService("HttpService")
+
 local attributesMap = require(script.Parent.Parent.AttributesMap)
 local attributeTypes = require(script.Parent.Parent.PropAttributeTypes)
 local versionCfg = require(script.Parent.Parent.Util.VersionConfig)
 
+local notificationMan = require(script.Parent.Parent.Util.Notifications.Manager)
 local internalAPI = require(script.Parent.Internal)
+
+local apiThread = coroutine.running()
 
 local function ValidateArgTypes(fname, ...)
 	local args = {...}
@@ -26,6 +31,28 @@ local function ValidateArgTypes(fname, ...)
 		end
 	end
 	return true
+end
+
+local function ValidateTableShape(fname, tbl, expected)
+	local keysMatch = true
+	local keyBad = nil
+
+	local argSettings = {}
+	for k, v in pairs(tbl) do
+		if expected[k] == nil then
+			keysMatch = false
+			keyBad = k
+			break
+		end
+		argSettings[#argSettings+1] = { k, v, expected[k] }
+	end
+
+	if not keysMatch then
+		warn(`Invalid table key {keyBad} passed to API function {fname}!`)
+		return false
+	end
+
+	return ValidateArgTypes(fname, unpack(argSettings))
 end
 
 type APIExtension = { [string] : (...any) -> ...any }
@@ -133,9 +160,32 @@ end
 
 --[[
 	[Args]
+		     Title // Description                                     // Example                                                                                       //
+		---------- // ----------------------------------------------- // -------------- -------------------------------------------------------------------------------//
+		notif_data // Table describing the relevant notification data // { Title = "Hello, World!", Description = "This is my first notification", Severity = "INFO" } //
+	[Returns]
+		1 - Nil if notification data did not pass validation
+			If notif data *did* pass validation, then returns a boolean indicating if the notification was displayed or not
+]]
+function publicAPI.PushNotification(notif_data) : boolean?
+	if not ValidateTableShape(
+		"PushNotification",
+		notif_data,
+		{
+			Title = "string",
+			Description = "string",
+			Severity = "number|string",
+			Rich = "boolean?"
+		}
+	) then return nil end
+	return notificationMan.Push(notif_data)
+end
+
+--[[
+	[Args]
 		     Title // Description                                                                       // Example                                   //
 		---------- // --------------------------------------------------------------------------------- // ----------------------------------------- //
-		  hookType // String corresponding to the type of hook being added                              // "PreSerialize"                            //
+		  hookType // String corresponding to the type of hook being removed                            // "PreSerialize"                            //
 		registrant // String representing the source of the hook. Should be unique                      // "MyPlugin"                                //
 		      hook // Function to be invoked when the corresponding hookType is invoked                 // function() print("Hook!") end             //
 		 hookState // (Optional) Extra state to be passed as the last argument to the hook when invoked // { PartCol = Color3.fromHex("#FFFFFF") }   //

--- a/Plugins/src/SerializationTools/Util/CommonColors.lua
+++ b/Plugins/src/SerializationTools/Util/CommonColors.lua
@@ -1,0 +1,39 @@
+local VIVID_GREEN = Color3.fromHex("3e983e")
+local DULL_GREEN  = Color3.fromHex("317032")
+
+local VIVID_RED = Color3.fromHex("ca4b4b")
+local DULL_RED  = Color3.fromHex("aa5559")
+
+local VIVID_BLUE = Color3.fromHex("4a9ec8")
+local DULL_BLUE  = Color3.fromHex("5191b4")
+
+local VIVID_PURPLE = Color3.fromHex("834ac8")
+local DULL_PURPLE  = Color3.fromHex("7f58b0")
+
+local VIVID_YELLOW = Color3.fromHex("cfc74b")
+local DULL_YELLOW  = Color3.fromHex("96923c")
+
+return {
+	WHITE  = Color3.fromHex("ffffff"),
+	GRAY   = Color3.fromHex("232526"),
+	BLACK  = Color3.fromHex("000000"),
+
+	VIVID_RED    = VIVID_RED,
+	VIVID_GREEN  = VIVID_GREEN,
+	VIVID_BLUE   = VIVID_BLUE,
+	VIVID_PURPLE = VIVID_PURPLE,
+	VIVID_YELLOW = VIVID_YELLOW,
+
+	DULL_RED    = DULL_RED,
+	DULL_GREEN  = DULL_GREEN,
+	DULL_BLUE   = DULL_BLUE,
+	DULL_PURPLE = DULL_PURPLE,
+	DULL_YELLOW = DULL_YELLOW,
+
+	LEGEND_RED       = VIVID_RED,
+	OPERATIVE_PURPLE = VIVID_PURPLE,
+	RECRUIT_BLUE     = VIVID_BLUE,
+	SOLO_GREEN       = VIVID_GREEN,
+	CHALLENGE_YELLOW = VIVID_YELLOW,
+
+}

--- a/Plugins/src/SerializationTools/Util/FeatureCheck.lua
+++ b/Plugins/src/SerializationTools/Util/FeatureCheck.lua
@@ -73,7 +73,9 @@ local function parseSerializerFeatures()
 	return featureDict
 end
 
-return function(featureName)
+return function(featureName, allFeaturesWorks)
+	allFeaturesWorks = if allFeaturesWorks == nil then true else allFeaturesWorks
+
 	local featureValue = workspace:GetAttribute(featureName)
 	if featureValue ~= nil then
 		return featureValue
@@ -84,7 +86,7 @@ return function(featureName)
 		return featCfg[featureName]
 	end
 	
-	if workspace:GetAttribute("SerializerEnableAllFeatures") == true then
+	if workspace:GetAttribute("SerializerEnableAllFeatures") == true and allFeaturesWorks then
 		return true
 	end
 end

--- a/Plugins/src/SerializationTools/Util/Frame.lua
+++ b/Plugins/src/SerializationTools/Util/Frame.lua
@@ -1,0 +1,96 @@
+local Actor = require(script.Parent.Actor)
+local Create = Actor.Create
+local State = Actor.State
+local Derived = Actor.Derived
+
+local FrameMod = {}
+
+local function merge(props, defaults)
+	for k, v in pairs(defaults) do
+		if props[k] == nil then
+			props[k] = v
+		end
+	end
+	return props
+end
+
+local function _frame(props, children)
+	merge(props, { BorderSizePixel = 0, ClipsDescendants = true })
+	return Create("Frame", props, children)
+end
+
+function FrameMod.Colored(color, props, children)
+	props.BackgroundColor3 = color
+	return _frame(
+		props,
+		children
+	)
+end
+
+function FrameMod.Invisible(props, children)
+	return _frame(
+		merge(props, { BackgroundTransparency = 1 }),
+		children
+	)
+end
+
+function FrameMod.Standard(props, children)
+	return _frame(
+		merge(props, { BackgroundTransparency = 0.5, BackgroundColor3 = Color3.new(0,0,0) }),
+		children
+	)
+end
+
+function FrameMod.Round(frame, by)
+	local corner = Create("UICorner", { CornerRadius = UDim.new(0, by) })
+
+	corner.Parent = frame
+	return frame, corner
+end
+
+local sideToRot = {
+	Top = 90,
+	Right = 180,
+	Left = 0,
+	Bottom = -90
+}
+function FrameMod.RoundSide(frame, by, side)
+	-- Abuses some jank found on the devforum
+	-- Why is this not a built-in thing?
+	local corner = Create("UICorner", { CornerRadius = UDim.new(0, by) })
+
+	local rot = sideToRot[side] or 0
+
+	local stroke = Create("UIStroke", {
+		Color = frame.BackgroundColor3,
+		LineJoinMode = Enum.LineJoinMode.Bevel,
+		Thickness = 0.1
+	}, {
+		Create("UIGradient", {
+			Rotation = rot,
+			Transparency = NumberSequence.new(0, 1)
+		})
+	})
+
+	-- Extra sprinkle of weirdness on top
+	-- Patches up some single-pixel holes around the edges
+	local patchUp = FrameMod.Colored(frame.BackgroundColor3, {
+		Size = UDim2.fromScale(1, 1)
+	}, {
+		corner:Clone()
+	})
+
+	local colorUpdate = frame:GetPropertyChangedSignal("BackgroundColor3"):Connect(function() stroke.Color = frame.BackgroundColor3 patchUp.BackgroundColor3 = frame.BackgroundColor3 end)
+	frame.Destroying:Once(function() colorUpdate:Disconnect() end)
+
+	patchUp.Parent = frame
+	corner.Parent = frame
+	stroke.Parent = frame
+	return frame, corner, stroke
+end
+
+-- Please don't kill me for this
+-- I figure it makes sense to at least imitate the interface of Button()
+setmetatable( FrameMod, { __call = function(self, ...) return FrameMod.Standard(...) end } )
+
+return FrameMod

--- a/Plugins/src/SerializationTools/Util/Notifications/GuiFactory.lua
+++ b/Plugins/src/SerializationTools/Util/Notifications/GuiFactory.lua
@@ -1,0 +1,186 @@
+local runService = game:GetService("RunService")
+
+local commonColour  = require(script.Parent.Parent.Parent.Util.CommonColors)
+local notifSeverity = require(script.Parent.Severity)
+
+-- We get to do UI, yay!
+local Actor = require(script.Parent.Parent.Parent.Util.Actor)
+local Create = Actor.Create
+local State = Actor.State
+local Derived = Actor.Derived
+local Frame = require(script.Parent.Parent.Parent.Util.Frame)
+
+local textBoundsParams = Instance.new("GetTextBoundsParams")
+
+return function(sizeState, timeState)
+
+	return function(data)
+
+		local severityData = data.Severity
+		local duration = timeState._Value * severityData.TimeMult
+
+		local livedDuration = State(0)
+		local lifetimeFac  = Derived(function(dur)
+			if math.isinf(duration) then
+				return 0
+			end
+			return dur / duration
+		end, livedDuration)
+
+		local lifetimeCol  = Derived(function(fac)
+			if math.isinf(duration) then
+				return severityData.Color
+			end
+			return commonColour.SOLO_GREEN:Lerp(commonColour.LEGEND_RED, fac)
+		end, lifetimeFac)
+		local lifetimeSize = Derived(function(fac) return UDim2.new(1 - fac, 0, 0, 8) end, lifetimeFac)
+
+		local lifetimePanel = Frame.RoundSide(Frame.Colored(
+			lifetimeCol,
+			{
+				AnchorPoint = Vector2.yAxis,
+
+				Size = lifetimeSize,
+				Position = UDim2.new(0, 0, 1, 0),
+				Name = "LifetimeBar"
+			}
+		), 8, "Top")
+
+		local notifContentTitleIcon = Create(
+			"ImageLabel",
+			{
+				AnchorPoint = Vector2.new(1, 0.5),
+				Position = UDim2.fromScale(1, 0.5),
+				Size     = UDim2.fromOffset(24, 24),
+				SizeConstraint = Enum.SizeConstraint.RelativeYY,
+				BackgroundTransparency = 1,
+				ImageTransparency = 0.5,
+				Image = `rbxassetid://{severityData.ImageID}`,
+				-- Not a fan of how this looks
+				--ImageColor3 = severityData.Color
+			}
+		)
+
+		local notifContentTitle = Create(
+			"TextLabel",
+			{
+				Text = data.Title,
+				TextColor3 = commonColour.WHITE,
+				Name = "Title",
+				Size = UDim2.fromScale(1, 0.25),
+				FontFace = Font.fromName("Zekton", Enum.FontWeight.Bold),
+				TextScaled = true,
+				TextXAlignment = Enum.TextXAlignment.Left,
+				BackgroundTransparency = 1,
+			},
+			{
+				notifContentTitleIcon,
+				Create("UITextSizeConstraint", { MaxTextSize = 21 })
+			}
+		)
+
+		local notifContentSeparator = Frame.Colored(
+			severityData.Color,
+			{
+				Name = "Separator",
+				Size = UDim2.new(1, 0, 0, 2),
+			}
+		)
+
+		local notifContentDesc = Create(
+			"TextLabel",
+			{
+				Text = data.Description,
+				TextColor3 = commonColour.WHITE,
+				TextTruncate = Enum.TextTruncate.SplitWord,
+				TextWrapped = true,
+				TextSize = 16,
+				TextXAlignment = Enum.TextXAlignment.Left,
+				TextYAlignment = Enum.TextYAlignment.Top,
+				Name = "Description",
+				Size = UDim2.new(1, -8, 1, 0),
+				BackgroundTransparency = 1,
+				FontFace = Font.fromName("Zekton"),
+				RichText = data.Rich or false,
+			}
+		)
+
+		-- TODO: Figure this out later
+		-- Got some incredibly buggy results with trying to use the built-in auto-scaling on the canvas
+		-- I've been sitting on these changes for like a week now and I would like to get a patch up
+		-- This can be revisited when I come back to add support for using these as help/keybind dialogues
+		local notifContentDescPanel = Create(
+			"ScrollingFrame",
+			{
+				Name = "Description_Panel",
+				BackgroundTransparency = 1,
+				Size = UDim2.new(1, 0, 0.75, -14),
+				ScrollBarThickness = 8,
+				CanvasSize = UDim2.fromScale(0, 0)
+			},
+			{
+				notifContentDesc
+			}
+		)
+
+		local notifContentPanelList = Create("UIListLayout", {
+			Padding = UDim.new(0, 2),
+			SortOrder = Enum.SortOrder.LayoutOrder,
+			HorizontalFlex = Enum.UIFlexAlignment.Fill
+		})
+
+		local notifContentPanelPad = Create("UIPadding", {
+			PaddingBottom = UDim.new(0, 4),
+			PaddingLeft   = UDim.new(0, 4),
+			PaddingRight  = UDim.new(0, 4),
+			PaddingTop    = UDim.new(0, 4),
+		})
+
+		local notifContentPanel = Frame.Round(Frame.Colored(
+			commonColour.GRAY,
+			{
+				Name = "Content",
+				Size = UDim2.fromScale(1, 1)
+			},
+			{
+				notifContentPanelList,
+				notifContentPanelPad,
+				notifContentTitle,
+				notifContentSeparator,
+				notifContentDescPanel
+			}
+		), 8)
+
+		local notifPanel = Frame.Invisible(
+			{
+				Name = `Notif_{data.Title:gsub("%s", "")}_Panel`,
+				Size = UDim2.new(1, 0, 0, sizeState._Value),
+			},
+			{
+				notifContentPanel,
+				lifetimePanel
+			}
+		)
+
+		local consume = function()
+			task.spawn(function()
+				local runServiceSignal = runService.Heartbeat:Connect(function(dt)
+					if notifPanel == nil then return end
+					if notifPanel.GuiState == Enum.GuiState.Idle then
+						livedDuration:set(livedDuration._Value + dt)
+					end
+					if notifPanel.GuiState == Enum.GuiState.Press then
+						livedDuration:set(math.huge)
+					end
+					if livedDuration._Value >= duration then
+						notifPanel:Destroy()
+					end
+				end)
+				notifPanel.Destroying:Wait()
+				runServiceSignal:Disconnect()
+			end)
+		end
+
+		return notifPanel, consume
+	end
+end

--- a/Plugins/src/SerializationTools/Util/Notifications/Manager.lua
+++ b/Plugins/src/SerializationTools/Util/Notifications/Manager.lua
@@ -1,0 +1,203 @@
+local FeatureCheck = require(script.Parent.Parent.Parent.Util.FeatureCheck)
+
+local NotifSeverity = require(script.Parent.Severity)
+
+-- We get to do UI, yay!
+local Actor = require(script.Parent.Parent.Parent.Util.Actor)
+local Create = Actor.Create
+local State = Actor.State
+local Derived = Actor.Derived
+
+local NOTIF_PAD = 8
+local SCROLLBAR_SIZE = 8
+
+local NOTIF_SIZE_FEAT = "SerializerNotifSize"
+local DEFAULT_NOTIF_SIZE = 125
+
+local NOTIF_TIME_FEAT = "SerializerNotifDuration"
+local DEFAULT_NOTIF_TIME = 5
+
+local NotificationManager = {}
+
+local _stackPos = 1
+local _notifStack = {}
+
+local canvasSizeState = State(0)
+local notifSizeState  = State(0)
+local notifTimeState  = State(0)
+
+local GuiFactory = require(script.Parent.GuiFactory)(notifSizeState, notifTimeState)
+
+local desc_tags = { ["%[tab%]"] = '\t' }
+
+local function description_sanitise(desc)
+	desc = desc:gsub("[ \r\t]*\n[ \r\t]*", "\n"):gsub("^%s*", ""):gsub("%s*$", "")
+	for tag, repl in pairs(desc_tags) do
+		desc = desc:gsub(tag, repl)
+	end
+	return desc
+end
+
+local function feature_state_updator(state, featName, default, minimum, falseValue)
+	if falseValue == nil then falseValue = minimum end
+	return function()
+		local setVal = FeatureCheck(featName, false)
+		local setType = type(setVal)
+
+		if setType ~= "number" and setType ~= "nil" and setType ~= "boolean" then
+			warn(`{featName} set to non-numeric non-nil value! Will use default of {default}`)
+			NotificationManager.Push{
+				Title = `Bad {featName} Value!`,
+				Description = `{featName} must be nil or a number!\n\nA default of {default} will be used.`,
+				Severity = "INFO"
+			}
+		end
+
+		if setType == "boolean" then
+			setVal = setVal and default or falseValue
+		end
+
+		setVal = setVal or default
+
+		if setVal < minimum then
+			warn(`{featName} set to unreasonably small value (< {minimum})! Will use default of {default}`)
+			NotificationManager.Push{
+				Title = `Bad {featName} Value!`,
+				Description = `{featName} was set to an unreasonably small value of {setVal}! A value of {minimum} or greater is expected.\n\n` ..
+							  `A default of {default} will be used.`,
+				Severity = "INFO"
+			}
+			setVal = DEFAULT_NOTIF_SIZE
+		end
+
+		state:set(
+			setVal
+		)
+	end
+end
+
+local update_notif_size = feature_state_updator(notifSizeState, NOTIF_SIZE_FEAT, DEFAULT_NOTIF_SIZE, 100)
+local update_notif_time = feature_state_updator(notifTimeState, NOTIF_TIME_FEAT, DEFAULT_NOTIF_TIME, 1.5, math.huge)
+
+local function fuzzy_compare(num1, num2, epsilon)
+	return math.abs(num1 - num2) <= epsilon
+end
+
+local function update_canvas_size(by)
+	local pad = NOTIF_PAD * math.sign(by)
+	canvasSizeState:set(canvasSizeState._Value + by + pad)
+end
+
+local function update_canvas_size_sticky(frame, by)
+	local beforePos = frame.CanvasPosition.Y
+	local canvasExtra = frame.AbsoluteCanvasSize.Y - frame.AbsoluteWindowSize.Y
+
+	-- Yes, floating point imprecision was breaking this code
+	-- No, I'm not happy about it
+	local sticky = fuzzy_compare(beforePos, canvasExtra, 0.01)
+
+	update_canvas_size(by)
+
+	if sticky then
+		frame.CanvasPosition = Vector2.new(frame.CanvasPosition.X, (frame.AbsoluteCanvasSize.Y - frame.AbsoluteWindowSize.Y))
+	end
+end
+
+function NotificationManager.Push(notif_data)
+	if NotificationManager.Panel == nil then return false end
+	local success, sev = NotifSeverity.FromInput(notif_data.Severity)
+	if not success then
+		warn(`Severity "{notif_data.Severity}" is not valid!`)
+		return false
+	end
+	notif_data.Severity = sev
+	notif_data.Description = description_sanitise(notif_data.Description)
+	local notif, consume = GuiFactory(notif_data)
+	notif.Parent = NotificationManager.Panel
+	update_canvas_size_sticky(NotificationManager.Panel, notif.AbsoluteSize.Y)
+	notif.Destroying:Once( function() 
+		if NotificationManager.Panel == nil then return end
+		update_canvas_size_sticky(NotificationManager.Panel, -notif.AbsoluteSize.Y)
+	end )
+	consume()
+	return true
+end
+
+function NotificationManager.Init()
+	if NotificationManager.Active then
+		return NotificationManager.Panel
+	end
+	NotificationManager.Active = true
+
+	canvasSizeState:set(0)
+
+	local panel = Create(
+		"ScrollingFrame",
+		{
+			Name = "NotificationPanel",
+			BackgroundTransparency = 1,
+			Position = UDim2.new(1, -50, 1, -50),
+			Size = UDim2.new(0.5, -50, 0.5, -50),
+			AnchorPoint = Vector2.new(1, 1),
+			ScrollBarThickness = SCROLLBAR_SIZE,
+			ScrollingDirection = Enum.ScrollingDirection.Y,
+			CanvasSize = Derived(function(newSize)
+				return UDim2.fromOffset(0, newSize)
+			end, canvasSizeState),
+			BorderSizePixel = 0,
+			--ScrollingEnabled = false
+		},
+		{
+			Create(
+				"UIListLayout",
+				{
+					Padding = UDim.new(0, NOTIF_PAD),
+					FillDirection = Enum.FillDirection.Vertical,
+					HorizontalFlex = Enum.UIFlexAlignment.Fill,
+					VerticalAlignment = Enum.VerticalAlignment.Bottom
+				}
+			),
+			Create(
+				"UIPadding",
+				{
+					PaddingRight = UDim.new(0, SCROLLBAR_SIZE)
+				}
+			)
+		}
+	)
+
+	NotificationManager.Panel = panel
+
+	update_notif_size()
+	update_notif_time()
+
+	local signals = {}
+	signals[1] = workspace:GetAttributeChangedSignal(NOTIF_SIZE_FEAT):Connect(update_notif_size)
+	signals[2] = workspace:GetAttributeChangedSignal(NOTIF_TIME_FEAT):Connect(update_notif_time)
+
+	NotificationManager.Signals = signals
+
+	return panel
+end
+
+local signals = {}
+
+
+function NotificationManager.Clean()
+	if not NotificationManager.Active then
+		return
+	end
+	NotificationManager.Active = false
+
+	if NotificationManager.Panel ~= nil then
+		NotificationManager.Panel:Destroy()
+		NotificationManager.Panel = nil
+	end
+
+	for i, signal in ipairs(signals) do
+		signal:Disconnect()
+		signals[i] = nil
+	end
+end
+
+return NotificationManager

--- a/Plugins/src/SerializationTools/Util/Notifications/Severity.lua
+++ b/Plugins/src/SerializationTools/Util/Notifications/Severity.lua
@@ -1,0 +1,56 @@
+local commonColours = require(script.Parent.Parent.Parent.Util.CommonColors)
+
+local function severity_data(id, time_mult, img, color) return { ID = id, ImageID = img, TimeMult = time_mult, Color = color } end
+local SEVERITY_DATA = {
+	INFO       = severity_data(0, 1,   "17829948066", commonColours.RECRUIT_BLUE),
+	WARN       = severity_data(1, 1.5, "17829955945", commonColours.CHALLENGE_YELLOW),
+	ERR        = severity_data(2, 2,   "17829927053", commonColours.LEGEND_RED),
+	ERR_SEVERE = severity_data(3, 2.5, "13201179730", commonColours.LEGEND_RED)
+}
+
+local IDS = {}
+local MIN, MAX = nil, nil
+local ID_MIN, ID_MAX = math.huge, -math.huge
+for k, v in pairs(SEVERITY_DATA) do
+	IDS[k] = v.ID
+	if ID_MIN > v.ID then
+		MIN = v
+		ID_MIN = v.ID
+	elseif ID_MAX < v.ID then
+		MAX = v
+		ID_MAX = v.ID
+	end
+end
+
+SEVERITY_DATA.MIN = MIN
+SEVERITY_DATA.MAX = MAX
+
+local sevmod = {}
+sevmod.Data = SEVERITY_DATA
+sevmod.IDs  = IDS
+
+function sevmod.FromId(id)
+	local clamped = math.clamp(id, ID_MIN, ID_MAX)
+	if clamped ~= id then
+		warn(`Notifications.Severity.FromId > ID {id} is out of bounds? Will default to {clamped}`)
+	end
+	return sevmod.Data[clamped]
+end
+
+function sevmod.FromName(name)
+	local found = SEVERITY_DATA[name]
+	return found ~= nil, found
+end
+
+function sevmod.FromInput(input)
+	local inT = type(input)
+	if inT == "number" then
+		return true, sevmod.FromId(input)
+	elseif inT == "string" then
+		return sevmod.FromName(input)
+	else
+		return false, nil
+	end
+end
+
+return sevmod

--- a/Plugins/src/SerializationTools/Writing/Main.lua
+++ b/Plugins/src/SerializationTools/Writing/Main.lua
@@ -4,7 +4,9 @@ local InternalAPI = require(script.Parent.Parent.API.Internal)
 local Write = require(script.Parent.Write)
 local StringConversion = require(script.Parent.Parent.Util.StringConversion)
 local Read = require(script.Parent.Parent.Reading.Read)
+
 local ReadbackButton = require(script.Parent.ReadbackButton)
+local NotifMan = require(script.Parent.Parent.Util.Notifications.Manager)
 
 local Button = require(script.Parent.Parent.Util.Button)
 local FeatureCheck = require(script.Parent.Parent.Util.FeatureCheck)
@@ -116,6 +118,7 @@ module.Init = function(mouse: PluginMouse)
 		return codeChunks
 	end, CodeState)
 
+	local notifDisabled	= FeatureCheck("SerializerNotifsDisabled", false) == true
 	local apiDevEnabled = FeatureCheck("APIDev") == true
 	local gistEnabled = FeatureCheck("ReadDocs") == true
 	local readbackEnabled = FeatureCheck("Readback") == true
@@ -132,6 +135,7 @@ module.Init = function(mouse: PluginMouse)
 			Activated = function()
 				InitCustomMissionSettings(false)
 				local code = GetMissionCode()
+				if code == nil then return end
 
 				if not workspace:FindFirstChild("DebugMission") then
 					local model = Read.Mission(code, 1)
@@ -149,6 +153,7 @@ module.Init = function(mouse: PluginMouse)
 				Activated = function()
 					local customSettings = InitCustomMissionSettings(true)
 					local code = GetMissionCode()
+					if code == nil then return end
 
 					if not workspace:FindFirstChild("DebugMission") then
 						local model = Read.Mission(code, 1)
@@ -188,6 +193,9 @@ module.Init = function(mouse: PluginMouse)
 					preprocessed.Parent = workspace
 				end,
 			})
+			else nil,
+		if not notifDisabled
+			then NotifMan.Init()
 			else nil,
 		Create("ScrollingFrame", {
 			Size = UDim2.new(0, 200, 1, apiDevEnabled and -180 or -130),
@@ -258,8 +266,10 @@ module.Clean = function()
 	end
 	module.Active = false
 
-	module.UI:Destroy()
-	module.UI = nil
+	if module.UI then
+		module.UI:Destroy()
+		module.UI = nil
+	end
 end
 
 return module

--- a/Plugins/src/SerializationTools/Writing/ReadbackButton.lua
+++ b/Plugins/src/SerializationTools/Writing/ReadbackButton.lua
@@ -3,6 +3,8 @@ local HttpService = game:GetService("HttpService")
 
 local Read = require(script.Parent.Parent.Reading.Read)
 
+local NotifMan = require(script.Parent.Parent.Util.Notifications.Manager)
+
 local Actor = require(script.Parent.Parent.Util.Actor)
 local Create = Actor.Create
 local State = Actor.State
@@ -19,6 +21,15 @@ local GIST_NONRAW_INFO_PAT   = `{GIST_NONRAW_BASE}/({URL_ELEM})/({URL_ELEM})`
 local GIST_URL_BASE          = HTTPS_BASE .. "gist%.githubusercontent%.com"
 local GIST_INFO_PAT_NO_NAME  = `{GIST_URL_BASE}/({URL_ELEM})/{URL_ELEM}/raw`
 local GIST_INFO_PAT_FILENAME = `{GIST_URL_BASE}/({URL_ELEM})/{URL_ELEM}/raw/{URL_ELEM}/({URL_ELEM})`
+
+local function readbackError(desc)
+	NotifMan.Push{
+		Title = "Readback Failure",
+		Description = desc,
+		Severity = "ERR",
+		Rich = true
+	}
+end
 
 local textboxDefaults = {
 	Font = Enum.Font.SciFi,
@@ -105,6 +116,9 @@ local function createReadbackBox(enabledState)
 			local success, missionCode = gistLinkToMissionCode(inputText)
 			if not success then
 				readErrState:set(missionCode)
+				readbackError [[
+					Invalid gist link.
+				]]
 				return
 			end
 			inputText = missionCode
@@ -115,11 +129,25 @@ local function createReadbackBox(enabledState)
 			inputNoComment = inputText:match("!!!.-!!!(.+)")
 			if inputNoComment == nil then
 				readErrState:set("Invalid Opening Comment")
+				readbackError [[
+								Mission code's Opening Comment was invalid!
+
+								Check you have the right link and try again.
+				]]
 				return
 			end
 		end
 
-		local inputHeader, cursor = Read.MissionCodeHeader(inputNoComment, 1)
+		local success, inputHeader, cursor = pcall(Read.MissionCodeHeader, inputNoComment, 1)
+		if not success then
+			readErrState:set("Invalid Code Header")
+			readbackError [[
+				The header of the inputted code is not valid!
+
+				<font transparency="0.5" size="11">Please stop entering random text into that box</font>
+			]]
+		end
+
 		local inputContent = string.sub(inputNoComment, cursor)
 
 		local existingMapInfo = readbackState.MapInfo
@@ -132,12 +160,27 @@ local function createReadbackBox(enabledState)
 		codeInput.Text = ""
 		if existingMapInfo.CodeVersion ~= inputHeader.CodeVersion then
 			readErrState:set("Code Version Mismatch")
+			readbackError [[
+				The Code Version of the most recently entered code didn't match that of the previous code!
+
+				Check that the code parts you are entering belong to the same mission.
+			]]
 			return
 		elseif existingMapInfo.MapId ~= inputHeader.MapId then
 			readErrState:set("Map ID Mismatch")
+			readbackError [[
+				The Map ID of the most recently entered code didn't match that of the previous code!
+
+				Check that the code parts you are entering belong to the same mission.
+			]]
 			return
 		elseif existingMapInfo.CodeTotal ~= inputHeader.CodeTotal then
 			readErrState:set("Code Count Mismatch")
+			readbackError [[
+				The total mission code count of the most recently entered code didn't match that of the previous code!
+
+				Check that the code parts you are entering belong to the same mission.
+			]]
 			return
 		end
 
@@ -163,6 +206,17 @@ local function createReadbackBox(enabledState)
 		local success, errReason = VersionConfig:change_version(readbackState.MapInfo.CodeVersion)
 		if not success then
 			readErrState:set(errReason)
+			NotifMan.Push{
+				Title = "Internal Error",
+				Description = [[
+					Failed to change internal version compatibility settings!
+					The error reason has been printed to the Script Output.
+					Restart your studio to avoid potential issues with bad version settings.
+					Report this issue <b>ASAP</b>.
+				]],
+				Severity = "ERR_SEVERE",
+			}
+			warn(errReason)
 			VersionConfig:change_version(VersionConfig.LatestVersion)
 			return
 		end

--- a/Plugins/src/SerializationTools/Writing/Write.lua
+++ b/Plugins/src/SerializationTools/Writing/Write.lua
@@ -4,6 +4,8 @@ local WriteInstance = require(script.Parent.WriteInstance)
 
 local EnumTypes = require(script.Parent.Parent.Types.Enums.Main)
 
+local NotifMan = require(script.Parent.Parent.Util.Notifications.Manager)
+
 local VersionConfig = require(script.Parent.Parent.Util.VersionConfig)
 
 local Write
@@ -249,9 +251,22 @@ Write = {
 			mission:FindFirstChild("TableMissionSetup"):Destroy()
 		end
 
+		if MissionSetup.Colors == nil then
+			NotifMan.Push{
+				Title = "MissionSetup Error",
+				Description = [[
+								No Colors table was found in your MissionSetup!
+
+								An empty one will be used as placeholder.
+							]],
+				Severity = "WARN"
+			}
+			MissionSetup.Colors = {}
+		end
+
 		-- setting Color3s into tables for encoding
-		for i, v in pairs(MissionSetup["Colors"]) do
-			MissionSetup["Colors"][i] = { v.R, v.G, v.B }
+		for i, v in pairs(MissionSetup.Colors) do
+			MissionSetup.Colors[i] = { v.R, v.G, v.B }
 		end
 
 		local json = game:GetService("HttpService"):JSONEncode(MissionSetup)


### PR DESCRIPTION
This PR adds support for notifications as part of the Serializer's interface, and adds a few internal uses of them in places where errors could be made clearer for the average user who maybe doesn't dedicate part of their screen to the Script Output tab

The ability to push notifications to the Serializer's interface is also exposed via the API, so that third party plugins (as well as the official auxiliary tooling) can emit their own bespoke info/warnings/errors in a standardised user friendly manner.

Currently the notification system is restricted to only being active when the serializer panel is open, with the intent of changing this once it's more mature in a later patch - I'm not super sure on this myself, so if you would prefer, I can revise this when I have a free moment.

The hope is that later down the road, the notification interface can be repurposed for general purpose popups, such as on-screen control indicators for the auxiliary plugins' controls, or yes/no dialogues - some work is already in this patch to support this, as the notifications are decoupled from the function which restricts their lifetime to a timer, and there's bespoke handling for notifications of infinite duration.

Talk of the future now firmly out of the way, the current system is still modestly developed - notifications can be disabled via the `SerializerNotifsDisabled` flag, their lifetime can be customised via the `SerializerNotifDuration` attribute, and their vertical size can be customised via the `SerializerNotifSize` attribute. Timed notifications pause their timer whilst being hovered, and are immediately dismissed upon being clicked on.

There are also some other notable internal additions, such as the inclusion of portions of the game's colour palette in a module for use in the new UI, as well as a new Frame module mimicking the ergonomics of the Button module.

Finally, attached is a preview of one of the new built-in warning notifications
<img width="730" height="188" alt="image" src="https://github.com/user-attachments/assets/8565d437-323e-4baf-9455-539d578378e8" />

Sorry about the larger than anticipated code footprint, I hope it's all of acceptable quality and not too time consuming to look over. Thanks.