### PR TITLE
Serializer // Compression

### DIFF
--- a/Plugins/src/SerializationTools/Reading/Read.lua
+++ b/Plugins/src/SerializationTools/Reading/Read.lua
@@ -2,6 +2,8 @@ local StringConversion = require(script.Parent.Parent.Util.StringConversion)
 local InstanceTypes = require(script.Parent.Parent.Types.InstanceTypes)
 local ReadInstance = require(script.Parent.ReadInstance)
 
+local EncodingService = game:GetService("EncodingService")
+
 local EnumTypes = require(script.Parent.Parent.Types.Enums.Main)
 
 local VersionConfig = require(script.Parent.Parent.Util.VersionConfig)
@@ -251,6 +253,17 @@ Read = {
 				error("Malformed opening comment")
 			end
 			str = code
+		end
+		
+		if VersionConfig.UseCompression then
+			local uncompressed = buffer.create(#str)
+			buffer.writestring(uncompressed, 0, str)
+
+			if type(EncodingService:GetDecompressedBufferSize(uncompressed)) ~= "number" then
+				error("Invalid compressed mission buffer")
+			end
+
+			str = buffer.tostring( EncodingService:DecompressBuffer( EncodingService:Base64Decode(uncompressed), Enum.CompressionAlgorithm.Zstd ) )
 		end
 		
 		Root = nil

--- a/Plugins/src/SerializationTools/Util/VersionConfig.lua
+++ b/Plugins/src/SerializationTools/Util/VersionConfig.lua
@@ -1,8 +1,9 @@
-local VERSION_LATEST = 1
+local VERSION_LATEST = 2
 
 local CODE_VERSION_LOOKUP = {
-	[0] = { ReplaceNewlines = false },
-	[1] = { ReplaceNewlines = true  }
+	[0] = { ReplaceNewlines = false, UseCompression = false },
+	[1] = { ReplaceNewlines = true, UseCompression = false },
+	[2] = { ReplaceNewlines = true, UseCompression = true }
 }
 
 -- This works, Lua counts table lengths starting from 1
@@ -17,6 +18,7 @@ local versionConfig = {
 	VersionNumber_API = 1,
 	
 	ReplaceNewlines = true,
+	UseCompression  = true
 }
 
 function versionConfig.change_version(self, to)
@@ -30,5 +32,7 @@ function versionConfig.change_version(self, to)
 	self.VersionNumber = to
 	return true, nil
 end
+
+versionConfig:change_version(VERSION_LATEST)
 
 return versionConfig

--- a/Plugins/src/SerializationTools/Writing/Write.lua
+++ b/Plugins/src/SerializationTools/Writing/Write.lua
@@ -2,6 +2,10 @@ local StringConversion = require(script.Parent.Parent.Util.StringConversion)
 local InstanceTypes = require(script.Parent.Parent.Types.InstanceTypes)
 local WriteInstance = require(script.Parent.WriteInstance)
 
+local EncodingService = game:GetService("EncodingService")
+
+local FeatureCheck = require(script.Parent.Parent.Util.FeatureCheck)
+
 local EnumTypes = require(script.Parent.Parent.Types.Enums.Main)
 
 local VersionConfig = require(script.Parent.Parent.Util.VersionConfig)
@@ -289,7 +293,46 @@ Write = {
 		local colorMapStr = Write.ColorMap(colorMapArr)
 		local stringMapStr = Write.StringMap(stringMapArr)
 
-		return colorMapStr .. stringMapStr .. str
+		local missionStr = colorMapStr .. stringMapStr .. str
+
+		if not VersionConfig.UseCompression then return missionStr end
+		
+		local compressLevel = FeatureCheck("SerializerCompressionLevel", false)
+		
+		if type(compressLevel) ~= "number" then
+			if type(compressLevel) ~= "nil" then
+				warn(`SerializerCompressionLevel : Expected int|nil, got {type(compressLevel)} {compressLevel}! Will use default of 4`)
+			end
+			compressLevel = 4
+		end
+
+		local inputCompressLevel = compressLevel
+		compressLevel = math.round(compressLevel)
+		if compressLevel ~= inputCompressLevel then
+			warn(`SerializerCompressionLevel : Expected integer from range -7 <-> 22 inclusive, got {inputCompressLevel}! Will use rounded value of {compressLevel}`)
+		end
+
+		inputCompressLevel = compressLevel
+		compressLevel = math.clamp(compressLevel, -7, 22)
+
+		if compressLevel ~= inputCompressLevel then
+			warn(`SerializerCompressionLevel : Expected integer from range -7 <-> 22 inclusive, got {inputCompressLevel}! Will use clamped value of {compressLevel}`)
+		end
+
+		local buf = buffer.create(#missionStr)
+		buffer.writestring(buf, 0, missionStr)
+		
+		local compressedBuf = EncodingService:Base64Encode( EncodingService:CompressBuffer(buf, Enum.CompressionAlgorithm.Zstd, compressLevel) )
+
+		local compressedStr = buffer.readstring( compressedBuf, 0, buffer.len(compressedBuf) )
+
+		if FeatureCheck("SerializerCompressionStats") == true then
+			print(`=== Compression Stats ===`)
+			print(`Before Compression: {#missionStr * 0.001}K`)
+			print(`After Compression: {#compressedStr * 0.001}K`)
+		end
+
+		return compressedStr
 	end,
 
 	Instance = function(object, colorMap, stringMap)


### PR DESCRIPTION
Adds compression via EncodingService's implementation of ZStd compression

Compression level is exposed via the `SerializerCompressionLevel` attribute, with a minimum value of -7 and a maximum of 22.
<sub>No I do not know why that is the range.</sub>

The default for the compression level is 4, for no real particular reason other than seeing decent enough gains while not creating any notable slowdown.

Compression stats can be enabled via the `SerializerCompressionStats` attribute, this was mainly just here for me to ensure it was working and doing things but I figured there was no reason to remove it so it's a feature now.

The biggest upside of this, funny enough, seems to be not having to render the labels for as many codes - for some reason this seems like a large portion of exporting overhead?

From my testing this handles reimporting my current 3 code mission from ReplicatedStorage just fine.