### PR TITLE
Serializer // Read & Write Optimizations

### DIFF
--- a/Plugins/src/SerializationTools/Reading/Read.lua
+++ b/Plugins/src/SerializationTools/Reading/Read.lua
@@ -1,19 +1,19 @@
+local EncodingService = game:GetService("EncodingService")
+local HttpService = game:GetService("HttpService")
+local ScriptEditorService = game:GetService("ScriptEditorService")
+
 local StringConversion = require(script.Parent.Parent.Util.StringConversion)
 local InstanceTypes = require(script.Parent.Parent.Types.InstanceTypes)
 local ReadInstance = require(script.Parent.ReadInstance)
-
-local EncodingService = game:GetService("EncodingService")
-
 local EnumTypes = require(script.Parent.Parent.Types.Enums.Main)
-
 local VersionConfig = require(script.Parent.Parent.Util.VersionConfig)
+local ReadBuild = require(script.Parent.ReadBuild)
 
 local SIGNED_INT_BOUND = StringConversion.GetMaxNumber(3) / 2
 local INT_BOUND = StringConversion.GetMaxNumber(4)
 local BOUNDED_FLOAT_BOUND = StringConversion.GetMaxNumber(3)
 local SHORT_BOUNDED_FLOAT_BOUND = StringConversion.GetMaxNumber(2)
 
-local Root
 local Read
 
 local denormalize = function(value)
@@ -21,7 +21,7 @@ local denormalize = function(value)
 end
 
 local InstanceKeys = {}
-for i, v in pairs(InstanceTypes) do
+for i, v in (InstanceTypes) do
 	InstanceKeys[v] = i
 end
 
@@ -45,21 +45,6 @@ local function NewlineGSub(capture)
 		return utf8.char(9)
 	end
 	return "&"
-end
-
-local function ResolvePath(root, pathString)
-	local current = root
-
-	for index in string.gmatch(pathString, "%d+") do
-		index = tonumber(index)
-		current = current:GetChildren()[index]
-
-		if not current then
-			return nil
-		end
-	end
-
-	return current
 end
 
 Read = {
@@ -150,21 +135,6 @@ Read = {
 		rz = denormalize(rz)
 		return CFrame.new(X, Y, Z) * CFrame.fromEulerAnglesXYZ(rx, ry, rz), cursor
 	end,
-	
-	InstanceReference = function(str, cursor)
-		local value, cursor = Read.String(str, cursor)
-
-		return function()
-			if Root then
-				if not Root:GetAttribute(`Loaded`) then
-					Root:GetAttributeChangedSignal(`Loaded`):Wait()
-				end
-				
-				local object = ResolvePath(Root, value)
-				return object
-			end
-		end, cursor
-	end,
 
 	BoundedFloat = function(str, cursor) -- returns the value read as a bounded float between 0-1. 3 symbols.
 		return StringConversion.StringToNumber(str, cursor, 3) / BOUNDED_FLOAT_BOUND, cursor + 3
@@ -232,12 +202,12 @@ Read = {
 
 	MissionCodeHeader = function(str, cursor)
 		local codeVersion, mapId, currentCode, totalCodes
-		
+
 		codeVersion, cursor = Read.ShortestInt(str, cursor)
 		mapId, cursor = Read.ShortInt(str, cursor)
 		currentCode, cursor = Read.ShortInt(str, cursor)
 		totalCodes, cursor = Read.ShortInt(str, cursor)
-		
+
 		return {
 			CodeVersion = codeVersion,
 			CodeCurrent = currentCode,
@@ -254,7 +224,7 @@ Read = {
 			end
 			str = code
 		end
-		
+
 		if VersionConfig.UseCompression then
 			local uncompressed = buffer.create(#str)
 			buffer.writestring(uncompressed, 0, str)
@@ -262,18 +232,17 @@ Read = {
 			str = buffer.tostring( EncodingService:DecompressBuffer( EncodingService:Base64Decode(uncompressed), Enum.CompressionAlgorithm.Zstd ) )
 		end
 		
-		Root = nil
 		local colorMap
 		colorMap, cursor = Read.ColorMap(str, cursor)
 		local stringMap
 		stringMap, cursor = Read.StringMap(str, cursor)
-		local mission = Read.Instance(str, cursor, colorMap, stringMap)
-
+		local node = Read.Instance(str, cursor, colorMap, stringMap)
+		local mission = ReadBuild.construct(node)
+		
 		-- Reading Color3s from TableMissionSetup
-		local ImportedMissionSetup = game:GetService("HttpService")
-			:JSONDecode(mission:FindFirstChild("TableMissionSetup").Value)
-
-		for i, v in pairs(ImportedMissionSetup["Colors"]) do
+		local missionSetup = mission:FindFirstChild(`TableMissionSetup`)
+		local ImportedMissionSetup = HttpService:JSONDecode(missionSetup and missionSetup.Value or `[]`)
+		for i, v in (ImportedMissionSetup["Colors"] or {}) do
 			ImportedMissionSetup["Colors"][i] = Color3.new(v[1], v[2], v[3])
 		end
 
@@ -282,9 +251,9 @@ Read = {
 			local MissionSetup = Instance.new("ModuleScript")
 			MissionSetup.Name = "MissionSetup"
 			MissionSetup.Parent = mission
-			MissionSetup.Source = StringMissionSetup.Value
+			MissionSetup.Source = StringMissionSetup and StringMissionSetup.Value or ``
 		end
-		
+
 		mission:SetAttribute(`Loaded`, true)
 		return mission
 	end,
@@ -294,20 +263,22 @@ Read = {
 		cursor += 1
 		if InstanceId ~= InstanceTypes.Nil then
 			local InstanceType = InstanceKeys[InstanceId]
-			local object, cursor = ReadInstance[InstanceType](str, cursor, Read, colorMap, stringMap)
-			if not Root and object.Name == `DebugMission` then
-				Root = object
-				Root:SetAttribute(`Loaded`, false)
+			local node, cursor = ReadInstance[InstanceType](str, cursor, Read, colorMap, stringMap)
+			if ReadBuild.rootNode == nil and node.Type == `Folder` and node.Properties.Name == `DebugMission` then
+				ReadBuild.rootNode = node
+				ReadBuild.rootNode.Root = true
+				ReadBuild.rootNode.Expensives = 0
+				ReadBuild.rootNode.Processed = 0
 			end
 			
 			while StringConversion.StringToNumber(str, cursor, 1) ~= 0 do
-				local child
-				child, cursor = Read.Instance(str, cursor, colorMap, stringMap)
-				if child ~= nil then
-					child.Parent = object
+				local subNode
+				subNode, cursor = Read.Instance(str, cursor, colorMap, stringMap)
+				if subNode ~= nil then
+					table.insert(node.Children, subNode)
 				end
 			end
-			return object, cursor + 1
+			return node, cursor + 1
 		else
 			return nil, cursor
 		end
@@ -328,7 +299,7 @@ Read = {
 
 	ResamplerMode = CreateEnumReader(Enum.ResamplerMode, EnumTypes.ResamplerMode),
 	SurfaceGuiSizingMode = CreateEnumReader(Enum.SurfaceGuiSizingMode, EnumTypes.SurfaceGuiSizingMode),
-	
+
 	TextureMode = CreateEnumReader(Enum.TextureMode, EnumTypes.TextureMode),
 }
 

--- a/Plugins/src/SerializationTools/Reading/Read.lua
+++ b/Plugins/src/SerializationTools/Reading/Read.lua
@@ -232,6 +232,7 @@ Read = {
 			str = buffer.tostring( EncodingService:DecompressBuffer( EncodingService:Base64Decode(uncompressed), Enum.CompressionAlgorithm.Zstd ) )
 		end
 		
+		ReadBuild.rootNode = nil
 		local colorMap
 		colorMap, cursor = Read.ColorMap(str, cursor)
 		local stringMap

--- a/Plugins/src/SerializationTools/Reading/ReadBuild.lua
+++ b/Plugins/src/SerializationTools/Reading/ReadBuild.lua
@@ -1,0 +1,179 @@
+local ReadBuild = {}
+local CollectionService = game:GetService("CollectionService")
+local InsertService = game:GetService("InsertService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local CachedUserMeshFolder = workspace:FindFirstChild("CachedUserMeshes")
+local ENABLE_ARBITRARY_MESHES = true
+
+local protectedBuild
+local build
+
+-- Limit threads to not nuke the scheduler
+local threadsLimit = 16
+local threadsActive = 0
+local threadsQueue = {}
+local function runNextThread()
+	if threadsActive >= threadsLimit then return end
+	local job = table.remove(threadsQueue, 1)
+	if not job then return end
+	
+	threadsActive += 1
+	task.spawn(function()
+		job()
+		threadsActive -= 1
+		runNextThread()
+	end)
+end
+
+local function enqueueThread(job)
+	table.insert(threadsQueue, job)
+	runNextThread()
+end
+
+-- // Helper Functions | All functions not necessary outside the module should stay localized for faster lookup
+local function resolvePath(pathString)
+	local path = string.split(pathString, `.`)
+	local current = ReadBuild.rootNode
+	for _, v in path do
+		local index = tonumber(v)
+		current = current.Children[index]
+	end
+	
+	return current.Instance
+end
+
+local function applyAttributes(instance, attributes)
+	for k, v in (attributes) do
+		instance:SetAttribute(k, v)
+	end
+end
+
+local function applyProperties(instance, properties)
+	for k, v in (properties) do
+		instance[k] = v
+	end
+end
+
+local function applyProtectedProperties(instance, properties)
+	for k, v in (properties) do
+		pcall(function()
+			instance[k] = v
+		end)
+	end
+end
+
+local function checkChildren(node, parent)
+	for _, child in (node.Children) do
+		if child.Protected then
+			enqueueThread(function()
+				protectedBuild(child, parent)
+			end)
+		else
+			build(child, parent)
+		end
+	end
+end
+
+local function applyNodeKeys(node, newInstance, parent)
+	checkChildren(node, newInstance)
+	node.Instance = newInstance
+	newInstance.Parent = parent
+end
+
+local function applyProtectedNodeKeys(node, newInstance, parent)
+	applyProtectedProperties(newInstance, node.Properties)
+	applyNodeKeys(node, newInstance, parent)
+end
+
+local function handleExpensive(node, newInstance)
+	local expensive = node.Expensive
+	if expensive then
+		for k,v in (expensive) do
+			newInstance[k] = resolvePath(v)
+		end
+	end
+end
+
+-- // Instance Construction
+protectedBuild = function(node, parent)
+	local newInstance = Instance.new(`Part`)
+	local instanceInitialized = false
+	local meshId = node.Properties.MeshId
+	local id = meshId and node.Properties.MeshId:match("%d+")
+	if id and #id > 3 then
+		meshId = id
+	end
+	node.Properties.MeshId = nil
+
+	local cachedMeshPart = meshId
+		and (
+			(
+				game.ReplicatedStorage:FindFirstChild("Assets")
+				and game.ReplicatedStorage.Assets:FindFirstChild("ImportParts")
+				and game.ReplicatedStorage.Assets.ImportParts:FindFirstChild(meshId)
+			) or (CachedUserMeshFolder and CachedUserMeshFolder:FindFirstChild(meshId))
+		)
+	
+	if cachedMeshPart then
+		newInstance = cachedMeshPart:Clone()
+		node.Properties.CollisionFidelity = nil
+		node.Properties.RenderFidelity = nil
+		instanceInitialized = true
+	elseif meshId and ENABLE_ARBITRARY_MESHES then
+		-- CreateMeshPartAsync is likely less reliable than cloning, so prefer using ImportParts when possible
+		local success, instOrReason = pcall(function()
+			local part = InsertService:CreateMeshPartAsync(
+				`rbxassetid://{meshId}`,
+				node.Properties["CollisionFidelity"] or Enum.CollisionFidelity.Default,
+				node.Properties["RenderFidelity"] or Enum.RenderFidelity.Automatic
+			)
+			if CachedUserMeshFolder then
+				local copy = part:Clone()
+				copy.Name = meshId
+				copy.Parent = CachedUserMeshFolder
+			end
+			return part
+		end)
+		node.Properties.CollisionFidelity = nil
+		node.Properties.RenderFidelity = nil
+		if success then
+			newInstance = instOrReason
+			instanceInitialized = true
+		end
+	end
+
+	if not instanceInitialized then
+		applyProtectedNodeKeys(node, newInstance, parent)
+	else
+		applyProperties(newInstance, node.Properties)
+		applyAttributes(newInstance, node.Attributes)
+		applyNodeKeys(node, newInstance, parent)
+	end
+	
+	ReadBuild.rootNode.Processed += 1
+	return newInstance
+end
+
+build = function(node, parent)
+	local newInstance = Instance.new(node.Type)
+	
+	handleExpensive(node, newInstance)
+	applyProperties(newInstance, node.Properties)
+	applyAttributes(newInstance, node.Attributes)
+	applyNodeKeys(node, newInstance, parent)
+	return newInstance
+end
+
+ReadBuild.rootNode = nil
+ReadBuild.construct = function(node, parent)
+	local newInstance = Instance.new(node.Type)
+	
+	applyProperties(newInstance, node.Properties)
+	applyAttributes(newInstance, node.Attributes)
+	applyNodeKeys(node, newInstance, parent)
+	repeat task.wait() until ReadBuild.rootNode.Processed >= ReadBuild.rootNode.Expensives -- Ensure all parallels are done processing before returning the root node
+	return newInstance
+end
+
+return ReadBuild

--- a/Plugins/src/SerializationTools/Reading/ReadBuild.lua
+++ b/Plugins/src/SerializationTools/Reading/ReadBuild.lua
@@ -1,4 +1,6 @@
 local ReadBuild = {}
+ReadBuild.rootNode = nil
+
 local CollectionService = game:GetService("CollectionService")
 local InsertService = game:GetService("InsertService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
@@ -40,6 +42,7 @@ local function resolvePath(pathString)
 		current = current.Children[index]
 	end
 	
+	if not current.Instance then repeat task.wait() until current.Instance end
 	return current.Instance
 end
 
@@ -90,7 +93,9 @@ local function handleExpensive(node, newInstance)
 	local expensive = node.Expensive
 	if expensive then
 		for k,v in (expensive) do
-			newInstance[k] = resolvePath(v)
+			enqueueThread(function()
+				newInstance[k] = resolvePath(v)
+			end)
 		end
 	end
 end
@@ -165,7 +170,6 @@ build = function(node, parent)
 	return newInstance
 end
 
-ReadBuild.rootNode = nil
 ReadBuild.construct = function(node, parent)
 	local newInstance = Instance.new(node.Type)
 	

--- a/Plugins/src/SerializationTools/Reading/ReadInstance.lua
+++ b/Plugins/src/SerializationTools/Reading/ReadInstance.lua
@@ -7,63 +7,42 @@ local InstanceProperties = require(script.Parent.Parent.Types.InstanceProperties
 local DefaultProperties = require(script.Parent.Parent.Types.DefaultProperties)
 local AttributeTypes = require(script.Parent.Parent.Types.AttributeTypes)
 local AttributeValidation = require(script.Parent.Parent.AttributeValidation)
+local ReadBuild = require(script.Parent.ReadBuild)
 
 local AttributeKeys = {}
-for i, v in pairs(AttributeTypes) do
+for i, v in (AttributeTypes) do
 	AttributeKeys[v] = i
 end
 
-local WithAttributes = function(DefaultReader)
-	return function(str, cursor, Read, colorMap, stringMap)
-		local newInstance
-		newInstance, cursor = DefaultReader(str, cursor, Read, colorMap, stringMap)
-		local attributeId = StringConversion.StringToNumber(str, cursor, 1)
-		cursor += 1
-		while not (attributeId == 0) do
-			local typeName = AttributeKeys[attributeId]
-			local nameMapIndex
-			nameMapIndex, cursor = Read.ShortInt(str, cursor)
-			local name = stringMap[nameMapIndex]
-			local value
-			if typeName == "Color3" then
-				local colorMapIndex
-				colorMapIndex, cursor = Read.ShortInt(str, cursor)
-				value = colorMap[colorMapIndex]
-			elseif typeName == "String" then
-				local valueMapIndex
-				valueMapIndex, cursor = Read.ShortInt(str, cursor)
-				value = stringMap[valueMapIndex]
-			else
-				value, cursor = Read[typeName](str, cursor)
-			end
-			newInstance:SetAttribute(name, value)
-			attributeId = StringConversion.StringToNumber(str, cursor, 1)
-			cursor += 1
-		end
-		local attributes = newInstance:GetAttributes()
-		attributes = AttributeValidation.Validate(newInstance.ClassName, newInstance.Name, attributes, true)
-		for i, v in pairs(attributes) do
-			newInstance:SetAttribute(i, v)
-		end
-		return newInstance, cursor
-	end
-end
-
 local ReadInstance
+local DefaultFlags = {
+	Protected = false,
+	Attributes = false,
+}
+local rootNode
 
-local CreateInstanceReader = function(instanceType, properties)
+local CreateInstanceReader = function(instanceType, properties, flags)
+	if not flags then flags = DefaultFlags end
 	local defaults = DefaultProperties[instanceType]
 
 	local InstanceReader = function(str, cursor, Read, colorMap, stringMap)
-		local newInstance = Instance.new(instanceType)
+		local node = {
+			Type = instanceType,
+			Children = {},
+			Attributes = {},
+			Properties = {},
+			Protected = flags.Protected or nil,
+		}
+		
 		if defaults then
-			for k, v in defaults do
-				newInstance[k] = v
+			for k, v in (defaults) do
+				node.Properties[k] = v
 			end
 		end
-		for i, v in pairs(properties) do -- sets all Instance properties to their default values as defined in InstanceProperties.lua
-			newInstance[v[1]] = v[3]
+		for i, v in (properties) do
+			node.Properties[v[1]] = v[3]
 		end
+
 		local propertyId = StringConversion.StringToNumber(str, cursor, 1)
 		cursor += 1
 		while not (propertyId == 0) do
@@ -72,145 +51,67 @@ local CreateInstanceReader = function(instanceType, properties)
 			if valueType == "Color3" then
 				local colorMapIndex
 				colorMapIndex, cursor = Read.ShortInt(str, cursor)
-				newInstance[typeName] = colorMap[colorMapIndex]
+				node.Properties[typeName] = colorMap[colorMapIndex]
 			elseif valueType == "String" then
 				local stringMapIndex
 				stringMapIndex, cursor = Read.ShortInt(str, cursor)
-				newInstance[typeName] = stringMap[stringMapIndex]
+				node.Properties[typeName] = stringMap[stringMapIndex]
 			elseif valueType == "InstanceReference" then
-				local set, newCursor = Read[valueType](str, cursor)
+				local pathString, newCursor = Read.String(str, cursor)
 				cursor = newCursor
-				task.spawn(function()
-					newInstance[typeName] = set()
-				end)
+				if not node.Expensive then node.Expensive = {} end
+				node.Expensive[typeName] = pathString
+				ReadBuild.rootNode.Expensives += 1
 			else
-				newInstance[typeName], cursor = Read[valueType](str, cursor)
+				node.Properties[typeName], cursor = Read[valueType](str, cursor)
 			end
 			propertyId = StringConversion.StringToNumber(str, cursor, 1)
 			cursor += 1
 		end
-		return newInstance, cursor
-	end
-	return InstanceReader
-end
-
-local CachedUserMeshFolder = game.ReplicatedStorage:FindFirstChild("Assets")
-if CachedUserMeshFolder then
-	CachedUserMeshFolder = CachedUserMeshFolder:FindFirstChild("LoadedMeshes")
-	if not CachedUserMeshFolder then
-		CachedUserMeshFolder = Instance.new("Folder")
-		CachedUserMeshFolder.Name = "LoadedMeshes"
-		CachedUserMeshFolder.Parent = game.ReplicatedStorage.Assets
-	end
-end
-
-local CreateProtectedInstanceReader = function(instanceType, properties)
-	local defaults = DefaultProperties[instanceType]
-
-	local InstanceReader = function(str, cursor, Read, colorMap, stringMap)
-		local newProperties = {}
-		if defaults then
-			for k, v in defaults do
-				newProperties[k] = v
-			end
-		end
-		for i, v in pairs(properties) do -- sets all Instance properties to their default values as defined in InstanceProperties.lua
-			newProperties[v[1]] = v[3]
-		end
-		local propertyId = StringConversion.StringToNumber(str, cursor, 1)
-		cursor += 1
-		while not (propertyId == 0) do
-			local typeName = properties[propertyId][1]
-			local valueType = properties[propertyId][2]
-			if valueType == "Color3" then
-				local colorMapIndex
-				colorMapIndex, cursor = Read.ShortInt(str, cursor)
-				newProperties[typeName] = colorMap[colorMapIndex]
-			elseif valueType == "String" then
-				local stringMapIndex
-				stringMapIndex, cursor = Read.ShortInt(str, cursor)
-				newProperties[typeName] = stringMap[stringMapIndex]
-			else
-				newProperties[typeName], cursor = Read[valueType](str, cursor)
-			end
-			propertyId = StringConversion.StringToNumber(str, cursor, 1)
+		
+		if flags.Attributes then
+			local attributeId = StringConversion.StringToNumber(str, cursor, 1)
 			cursor += 1
-		end
-
-		local newInstance = Instance.new("Part")
-		local instanceInitialized = false
-		local meshId = newProperties.MeshId
-		local id = meshId and newProperties.MeshId:match("%d+")
-		if id and #id > 3 then
-			meshId = id
-		end
-		newProperties.MeshId = nil
-
-		local cachedMeshPart = meshId
-			and (
-				(
-					game.ReplicatedStorage:FindFirstChild("Assets")
-					and game.ReplicatedStorage.Assets:FindFirstChild("ImportParts")
-					and game.ReplicatedStorage.Assets.ImportParts:FindFirstChild(meshId)
-				) or (CachedUserMeshFolder and CachedUserMeshFolder:FindFirstChild(meshId))
-			)
-		if cachedMeshPart then
-			newInstance = cachedMeshPart:Clone()
-			newProperties.CollisionFidelity = nil
-			newProperties.RenderFidelity = nil
-			for k, v in newProperties do
-				newInstance[k] = v
-			end
-			instanceInitialized = true
-		elseif meshId and ENABLE_ARBITRARY_MESHES then
-			-- CreateMeshPartAsync is likely less reliable than cloning, so prefer using ImportParts when possible
-			local success, instOrReason = pcall(function()
-				local part = InsertService:CreateMeshPartAsync(
-					`rbxassetid://{meshId}`,
-					newProperties["CollisionFidelity"] or Enum.CollisionFidelity.Default,
-					newProperties["RenderFidelity"] or Enum.RenderFidelity.Automatic
-				)
-				if CachedUserMeshFolder then
-					local copy = part:Clone()
-					copy.Name = meshId
-					copy.Parent = CachedUserMeshFolder
+			while not (attributeId == 0) do
+				local typeName = AttributeKeys[attributeId]
+				local nameMapIndex
+				nameMapIndex, cursor = Read.ShortInt(str, cursor)
+				local name = stringMap[nameMapIndex]
+				local value
+				if typeName == "Color3" then
+					local colorMapIndex
+					colorMapIndex, cursor = Read.ShortInt(str, cursor)
+					value = colorMap[colorMapIndex]
+				elseif typeName == "String" then
+					local valueMapIndex
+					valueMapIndex, cursor = Read.ShortInt(str, cursor)
+					value = stringMap[valueMapIndex]
+				else
+					value, cursor = Read[typeName](str, cursor)
 				end
-				return part
-			end)
-			newProperties.CollisionFidelity = nil
-			newProperties.RenderFidelity = nil
-			if success then
-				newInstance = instOrReason
-				for k, v in newProperties do
-					newInstance[k] = v
-				end
-				instanceInitialized = true
+				node.Attributes[name] = value
+				attributeId = StringConversion.StringToNumber(str, cursor, 1)
+				cursor += 1
 			end
+			node.Attributes = AttributeValidation.Validate(node.Properties.ClassName, node.Properties.Name, node.Attributes, true)
 		end
-
-		if not instanceInitialized then
-			for k, v in newProperties do
-				pcall(function()
-					newInstance[k] = v
-				end)
-			end
-		end
-
-		return newInstance, cursor
+		
+		return node, cursor
 	end
+	
 	return InstanceReader
 end
 
 ReadInstance = {
-	Model = WithAttributes(CreateInstanceReader("Model", InstanceProperties.Model)),
-	Folder = WithAttributes(CreateInstanceReader("Folder", InstanceProperties.Folder)),
-	Part = WithAttributes(CreateInstanceReader("Part", InstanceProperties.Part)),
+	Model = CreateInstanceReader(`Model`, InstanceProperties.Model, {Attributes = true}),
+	Folder = CreateInstanceReader(`Folder`, InstanceProperties.Folder, {Attributes = true}),
+	Part = CreateInstanceReader(`Part`, InstanceProperties.Part, {Attributes = true}),
 	PartNoAttributes = CreateInstanceReader("Part", InstanceProperties.Part),
-	BoolValue = WithAttributes(CreateInstanceReader("BoolValue", InstanceProperties.BoolValue)),
+	BoolValue = CreateInstanceReader(`BoolValue`, InstanceProperties.BoolValue, {Attributes = true}),
 	WedgePart = CreateInstanceReader("WedgePart", InstanceProperties.WedgePart),
 	StringValue = CreateInstanceReader("StringValue", InstanceProperties.StringValue),
-	MeshPart = WithAttributes(CreateProtectedInstanceReader("MeshPart", InstanceProperties.MeshPart)),
-	UnionOperation = WithAttributes(CreateProtectedInstanceReader("UnionOperation", InstanceProperties.UnionOperation)),
+	MeshPart = CreateInstanceReader(`MeshPart`, InstanceProperties.MeshPart, {Attributes = true, Protected = true}),
+	UnionOperation = CreateInstanceReader(`UnionOperation`, InstanceProperties.UnionOperation, {Attributes = true, Protected = true}),
 	Texture = CreateInstanceReader("Texture", InstanceProperties.Texture),
 	BlockMesh = CreateInstanceReader("BlockMesh", InstanceProperties.BlockMesh),
 	PointLight = CreateInstanceReader("PointLight", InstanceProperties.PointLight),

--- a/Plugins/src/SerializationTools/Writing/Write.lua
+++ b/Plugins/src/SerializationTools/Writing/Write.lua
@@ -34,7 +34,7 @@ end
 local function GetIndex(object)
 	local parent = object.Parent
 	local children = parent:GetChildren()
-	
+
 	local index = 1
 	for _, child in children do
 		if child == object then
@@ -43,7 +43,7 @@ local function GetIndex(object)
 			index += 1
 		end
 	end
-	
+
 	return index
 end
 
@@ -193,11 +193,11 @@ Write = {
 		end
 		return Write.Int(#str) .. str
 	end,
-	
+
 	InstanceReference = function(object)
 		local path = {}
 		local current = object
-		
+
 		-- Get parent path
 		while current and current.Parent and (current.Name ~= `DebugMission` and current ~= workspace) do
 			local index = GetIndex(current)
@@ -206,12 +206,12 @@ Write = {
 			end
 			current = current.Parent
 		end
-		
+
 		-- Reverse order
 		for i = 1, math.floor(#path / 2) do
 			path[i], path[#path - i + 1] = path[#path - i + 1], path[i]
 		end
-		
+
 		-- Concat
 		path = table.concat(path, `.`)
 		return Write.String(path)
@@ -219,7 +219,7 @@ Write = {
 
 	ColorMap = function(colorMap)
 		local colorStr = ""
-		for i, v in pairs(colorMap) do
+		for i, v in (colorMap) do
 			colorStr = colorStr .. Write.Color3(v)
 		end
 		return Write.ShortInt(#colorMap) .. colorStr
@@ -227,7 +227,7 @@ Write = {
 
 	StringMap = function(stringMap)
 		local stringStr = ""
-		for i, v in pairs(stringMap) do
+		for i, v in (stringMap) do
 			stringStr = stringStr .. Write.String(v)
 		end
 		return Write.ShortInt(#stringMap) .. stringStr
@@ -254,7 +254,7 @@ Write = {
 		end
 
 		-- setting Color3s into tables for encoding
-		for i, v in pairs(MissionSetup["Colors"]) do
+		for i, v in (MissionSetup["Colors"]) do
 			MissionSetup["Colors"][i] = { v.R, v.G, v.B }
 		end
 
@@ -282,11 +282,11 @@ Write = {
 		local colorMapArr = {}
 		local stringMapArr = {}
 
-		for colHex, colidx in pairs(colorMap) do
+		for colHex, colidx in (colorMap) do
 			colorMapArr[colidx] = Color3.fromHex(colHex)
 		end
 
-		for str, stridx in pairs(stringMap) do
+		for str, stridx in (stringMap) do
 			stringMapArr[stridx] = str
 		end
 
@@ -296,9 +296,9 @@ Write = {
 		local missionStr = colorMapStr .. stringMapStr .. str
 
 		if not VersionConfig.UseCompression then return missionStr end
-		
+
 		local compressLevel = FeatureCheck("SerializerCompressionLevel", false)
-		
+
 		if type(compressLevel) ~= "number" then
 			if type(compressLevel) ~= "nil" then
 				warn(`SerializerCompressionLevel : Expected int|nil, got {type(compressLevel)} {compressLevel}! Will use default of 4`)
@@ -321,7 +321,7 @@ Write = {
 
 		local buf = buffer.create(#missionStr)
 		buffer.writestring(buf, 0, missionStr)
-		
+
 		local compressedBuf = EncodingService:Base64Encode( EncodingService:CompressBuffer(buf, Enum.CompressionAlgorithm.Zstd, compressLevel) )
 
 		local compressedStr = buffer.readstring( compressedBuf, 0, buffer.len(compressedBuf) )
@@ -343,10 +343,11 @@ Write = {
 			end
 			local instanceType = StringConversion.NumberToString(InstanceTypes[className], 1)
 			local objectProperties, colorMap, stringMap = WriteInstance[className](object, Write, colorMap, stringMap)
-			local childrenProperties = ""
-			for i, v in pairs(object:GetChildren()) do
-				childrenProperties = childrenProperties .. Write.Instance(v, colorMap, stringMap)
+			local chunks = {}
+			for i, v in (object:GetChildren()) do
+				chunks[i] = (Write.Instance(v, colorMap, stringMap))
 			end
+			local childrenProperties = table.concat(chunks)
 			return instanceType .. objectProperties .. childrenProperties .. StringConversion.NumberToString(0, 1),
 			colorMap,
 			stringMap


### PR DESCRIPTION
This PR optimizes both the serializer and deserializer. For the deserializer, it's done by separating the deserialization and instance creation stages, as well as handling protected instances in parallel, resulting in a speed increase of ~87.7%. For the serializer, it's done by simply changing the string combination method from the usual string concation to a `table.concat` - results in a ~54.1% speed increase. Benchmarks will be provided at the end of the description for clearer readability.

A major part of this PR is a change as to how the deserializer... um... deserializes. Previously, it would deserialize *and* perform instance creation at the same time - resulting in a pretty uncontrollable and flawed process; to address this, the deserialization now first builds a "node table" of instances, *and then* performs the instance creation, not only allowing for more control but also improving readability for contributors as all instance creation logic resides in `ReadBuild.lua`, whilst the direct deserialization stays in `Read.lua` and `ReadInstance.lua`. Thanks to the node table, we're now able to tell how many instances we've got left during instance creation, meaning we can safely handle the more expensive instances (MeshParts, UnionOperations, etc..) in parallel, allowing the basic ones continue their creation without coming to a full stop just so a single MeshPart can be created. As for instance references (which as you may recall *were* dependant on child creation order) - they now use the node table, meaning the actual instances can be created in a completely different order and the instance references would still work, making them way more reliable. (reparenting them all across the the explorer and having them still load properly is very satisfying)

For benchmarking, I used the most recent template of *The Withdrawal*, as it has a decent amount of meshes and a pretty big map. In the results below, a cycle refers to a single process of serializing *and* deserializing the result of the serialization, instance creation included.

| Version | Cycles | Total Time | avg. Serialize | avg. Deserialize | avg. Cycle | Meshes Cached?
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
| Official | 50 | `89.15720100002363` | `0.5984696819959209` | `1.1743149839900433` | `1.7830028079915792` | Yes
| Optimized  | 50 | `21.593711800174788` | `0.27471011199522766` | `0.14434536397922784` | `0.431719339992851` | Yes
| Official | 25 | `45.192732099909335` | `0.6217225119844079` | `1.1750829600077122` | `1.8075687439739705` | Yes
| Optimized  | 25 | `10.788138800067827` | `0.2754281079955399` | `0.1434393440000713` | `0.43137111596763134` | Yes
| Official | 10 | `18.07633879990317` | `0.6226990900700912` | `1.1741714300122112` | `1.8074826799798758` | Yes
| Optimized  | 10 | `4.304527499945834` | `0.2734107600292191` | `0.14398487000726162` | `0.4302882600342855` | Yes
| Official | 5 | `8.993392799980938` | `0.620291420025751` | `1.1672632399946452` | `1.798508939985186` | Yes
| Optimized  | 5 | `2.0874057000037283` | `0.259314899938181` | `0.14539262000471354` | `0.4173031999729574` | Yes
| Official | 1 | `2.9421635000035167` | `0.6201438999269158` | `2.3116060998290777` | `2.9419378000311553` | No
| Optimized  | 1 | `0.6802312000654638` | `0.2701169999781996` | `0.39748629997484386` | `0.679992499994114` | No

*The benchmarking was done on my hardware and may vary for others*

meow :3