### PR TITLE
feat: CustomLighting Support

### DIFF
--- a/Plugins/src/InfiltrationEngineTools/LightingCapture/Main.lua
+++ b/Plugins/src/InfiltrationEngineTools/LightingCapture/Main.lua
@@ -37,7 +37,6 @@ function module.Capture()
 		return
 	end
 
-	-- Clear any existing capture
 	local existing = missionSetup:FindFirstChild("CustomLighting")
 	if existing then
 		existing:Destroy()
@@ -47,7 +46,6 @@ function module.Capture()
 	customLighting.Name = "CustomLighting"
 	customLighting.Value = true
 
-	-- Capture top-level Lighting properties as Attributes
 	for _, prop in LIGHTING_PROPS do
 		local ok, val = pcall(function() return Lighting[prop] end)
 		if ok and val ~= nil then
@@ -55,7 +53,6 @@ function module.Capture()
 		end
 	end
 
-	-- Capture Lighting children (PostEffects, Atmosphere, Sky, Clouds)
 	for _, child in Lighting:GetChildren() do
 		if not (child:IsA("PostEffect") or child:IsA("Atmosphere") or child:IsA("Sky") or child:IsA("Clouds")) then
 			continue

--- a/Plugins/src/InfiltrationEngineTools/LightingCapture/Main.lua
+++ b/Plugins/src/InfiltrationEngineTools/LightingCapture/Main.lua
@@ -1,0 +1,88 @@
+local module = {}
+
+local Lighting = game:GetService("Lighting")
+
+local LIGHTING_PROPS = {
+	"Ambient", "Brightness", "ColorShift_Bottom", "ColorShift_Top",
+	"EnvironmentDiffuseScale", "EnvironmentSpecularScale",
+	"GlobalShadows", "OutdoorAmbient", "ShadowSoftness",
+	"ClockTime", "GeographicLatitude", "ExposureCompensation",
+	"FogColor", "FogEnd", "FogStart",
+}
+
+local EFFECT_PROPS = {
+	Atmosphere           = { "Density", "Offset", "Color", "Decay", "Glare", "Haze" },
+	Sky                  = {
+		"SkyboxBk", "SkyboxDn", "SkyboxFt", "SkyboxLf", "SkyboxRt", "SkyboxUp",
+		"StarCount", "SunAngularSize", "SunTextureId", "MoonAngularSize", "MoonTextureId",
+		"MoonPhase", "CelestialBodiesShown",
+	},
+	BloomEffect          = { "Intensity", "Size", "Threshold", "Enabled" },
+	BlurEffect           = { "Size", "Enabled" },
+	ColorCorrectionEffect = { "Brightness", "Contrast", "Saturation", "TintColor", "Enabled" },
+	DepthOfFieldEffect   = { "FarIntensity", "FocusDistance", "InFocusRadius", "NearIntensity", "Enabled" },
+	SunRaysEffect        = { "Intensity", "Spread", "Enabled" },
+	Clouds               = { "Cover", "Density", "Color", "Enabled" },
+}
+
+function module.Capture()
+	if not workspace:FindFirstChild("DebugMission") then
+		warn("DebugMission not found in workspace!")
+		return
+	end
+
+	local missionSetup = workspace.DebugMission:FindFirstChild("MissionSetup")
+	if not missionSetup then
+		warn("MissionSetup not found inside DebugMission!")
+		return
+	end
+
+	-- Clear any existing capture
+	local existing = missionSetup:FindFirstChild("CustomLighting")
+	if existing then
+		existing:Destroy()
+	end
+
+	local customLighting = Instance.new("BoolValue")
+	customLighting.Name = "CustomLighting"
+	customLighting.Value = true
+
+	-- Capture top-level Lighting properties as Attributes
+	for _, prop in LIGHTING_PROPS do
+		local ok, val = pcall(function() return Lighting[prop] end)
+		if ok and val ~= nil then
+			customLighting:SetAttribute(prop, val)
+		end
+	end
+
+	-- Capture Lighting children (PostEffects, Atmosphere, Sky, Clouds)
+	for _, child in Lighting:GetChildren() do
+		if not (child:IsA("PostEffect") or child:IsA("Atmosphere") or child:IsA("Sky") or child:IsA("Clouds")) then
+			continue
+		end
+
+		local props = EFFECT_PROPS[child.ClassName]
+		if not props then
+			continue
+		end
+
+		local childVal = Instance.new("BoolValue")
+		childVal.Name = child.Name
+		childVal.Value = true
+		childVal:SetAttribute("ClassName", child.ClassName)
+
+		for _, prop in props do
+			local ok, val = pcall(function() return child[prop] end)
+			if ok and val ~= nil then
+				childVal:SetAttribute(prop, val)
+			end
+		end
+
+		childVal.Parent = customLighting
+	end
+
+	customLighting.Parent = missionSetup
+	print("CustomLighting captured to DebugMission/MissionSetup/CustomLighting")
+end
+
+return module

--- a/Plugins/src/InfiltrationEngineTools/Main.server.lua
+++ b/Plugins/src/InfiltrationEngineTools/Main.server.lua
@@ -14,6 +14,8 @@ local SectionVisibilityButton =
 	toolbar:CreateButton("Section Visibility", "Section Visibility", "rbxassetid://8753176416")
 local TerrainSerializationButton =
 	toolbar:CreateButton("Terrain Serialization", "Terrain Serialization", "rbxassetid://115396940325881")
+local LightingCaptureButton =
+	toolbar:CreateButton("Capture Lighting", "Capture custom lighting from game.Lighting", "rbxassetid://10652251260")
 
 local MeadowMap = require(script.Parent.MeadowMap.Main)
 local DoorAccess = require(script.Parent.DoorAccess.Main)
@@ -24,6 +26,7 @@ local ZoneMarker = require(script.Parent.ZoneMarker.Main)
 local AttributeSearch = require(script.Parent.AttributeSearch.Main)
 local SectionVisibility = require(script.Parent.SectionVisibility.Main)
 local TerrainSerialization = require(script.Parent.TerrainSerialization.Main)
+local LightingCapture = require(script.Parent.LightingCapture.Main)
 local CurrentPlugin = nil
 
 local VisibilityToggle = require(script.Parent.Util.VisibilityToggle)
@@ -55,6 +58,12 @@ ConnectPluginToButton(TerrainSerializationButton, TerrainSerialization)
 SectionVisibilityButton.Click:Connect(function()
 	plugin:Deactivate()
 	SectionVisibility.OpenMenu(plugin)
+	plugin:Deactivate()
+end)
+
+LightingCaptureButton.Click:Connect(function()
+	plugin:Deactivate()
+	LightingCapture.Capture()
 	plugin:Deactivate()
 end)
 

--- a/Plugins/src/InfiltrationEngineTools/Main.server.lua
+++ b/Plugins/src/InfiltrationEngineTools/Main.server.lua
@@ -15,7 +15,7 @@ local SectionVisibilityButton =
 local TerrainSerializationButton =
 	toolbar:CreateButton("Terrain Serialization", "Terrain Serialization", "rbxassetid://115396940325881")
 local LightingCaptureButton =
-	toolbar:CreateButton("Capture Lighting", "Capture custom lighting from game.Lighting", "rbxassetid://10652251260")
+	toolbar:CreateButton("Capture Lighting", "Capture custom lighting from game.Lighting", "")
 
 local MeadowMap = require(script.Parent.MeadowMap.Main)
 local DoorAccess = require(script.Parent.DoorAccess.Main)

--- a/Plugins/src/SerializationTools/Writing/Write.lua
+++ b/Plugins/src/SerializationTools/Writing/Write.lua
@@ -270,22 +270,25 @@ Write = {
 				end
 			end
 
-			local effectsArray = {}
+			local children = {}
 			for _, child in pairs(customLightingInst:GetChildren()) do
 				if child:IsA("BoolValue") and child.Value then
-					local childData = { Name = child.Name }
+					local className = child:GetAttribute("ClassName")
+					if not className then continue end
+					local childData = {}
 					for attr, val in pairs(child:GetAttributes()) do
+						if attr == "ClassName" then continue end
 						if typeof(val) == "Color3" then
 							childData[attr] = { val.R, val.G, val.B }
 						else
 							childData[attr] = val
 						end
 					end
-					table.insert(effectsArray, childData)
+					children[className] = childData
 				end
 			end
-			if #effectsArray > 0 then
-				customLightingData["Effects"] = effectsArray
+			if next(children) then
+				customLightingData["Children"] = children
 			end
 			MissionSetup["CustomLighting"] = customLightingData
 		end

--- a/Plugins/src/SerializationTools/Writing/Write.lua
+++ b/Plugins/src/SerializationTools/Writing/Write.lua
@@ -258,6 +258,38 @@ Write = {
 			MissionSetup["Colors"][i] = { v.R, v.G, v.B }
 		end
 
+		local missionSetupInst = mission:FindFirstChild("MissionSetup")
+		local customLightingInst = missionSetupInst and missionSetupInst:FindFirstChild("CustomLighting")
+		if customLightingInst and customLightingInst:IsA("BoolValue") and customLightingInst.Value then
+			local customLightingData = {}
+			for attr, val in pairs(customLightingInst:GetAttributes()) do
+				if typeof(val) == "Color3" then
+					customLightingData[attr] = { val.R, val.G, val.B }
+				else
+					customLightingData[attr] = val
+				end
+			end
+
+			local effectsArray = {}
+			for _, child in pairs(customLightingInst:GetChildren()) do
+				if child:IsA("BoolValue") and child.Value then
+					local childData = { Name = child.Name }
+					for attr, val in pairs(child:GetAttributes()) do
+						if typeof(val) == "Color3" then
+							childData[attr] = { val.R, val.G, val.B }
+						else
+							childData[attr] = val
+						end
+					end
+					table.insert(effectsArray, childData)
+				end
+			end
+			if #effectsArray > 0 then
+				customLightingData["Effects"] = effectsArray
+			end
+			MissionSetup["CustomLighting"] = customLightingData
+		end
+
 		local json = game:GetService("HttpService"):JSONEncode(MissionSetup)
 
 		local TableMissionSetup = Instance.new("StringValue")


### PR DESCRIPTION
### Custom Lighting 'Support'
This PR attempts to add support for CustomLighting by allowing users of the tooling to "capture their lighting" using the new Capture Lighting button in InfiltrationEngineTools. This retrieves the properties of Lighting (and its children) and places them into DebugMission/MissionSetup/CustomLighting, with a respective hierarchy. Once the user serializes, it is passed as a table in MissionSetup.

> Why isn't it just passed into MissionSetup automatically?

Seperate what the CM (Custom Mission) maker wants for their lighting and how the CM maker wants to work in, dev lighting vs act. lighting

**A side effect is the need for the data to be read within InfiltrationEngine.** I have tried to make this PR as accessible as possible so that there isn't that much work, but if you do not want the extra hassle of deliberetly adding code on your end to satisfy the PR, I will close it

The point of this PR is to allow CM makers to be able to create their own lighting parameters, without being trapped with the supplied default presets.

An example is shown with one of my custom missions, The Black Dawn
<img width="1562" height="627" alt="image" src="https://github.com/user-attachments/assets/877e3969-d08a-45f1-8e28-712edc5cc813" />
This is with my own lighting settings, achieving a foggy & "rising" look

But, with my fallback LightingSetting NightOrange, it loses that spark
<img width="1573" height="650" alt="image" src="https://github.com/user-attachments/assets/efccc122-d831-41db-bfb4-f6ddfa547dc8" />

Now that might be an extreme example _(and with the use of PBR textures that are not supported in EP:FC)_, it does apply to other CM makers that are looking to achieve a certain look, and are saddened to see that they are restricted to 5+ lighting options

_Note: There is no icon for Capture Lighting at the moment_