### PR TITLE
Serializer // VectorMap

### DIFF
--- a/Plugins/src/SerializationTools/AttributeValidation.lua
+++ b/Plugins/src/SerializationTools/AttributeValidation.lua
@@ -243,7 +243,7 @@ return {
 			return attributes
 		end
 
-		if attributes.IKnowWhatImDoingDoNotValidate == true then
+		if attributes.IKnowWhatImDoingDoNotValidate == true or attributes.IgnoreValidation == true then
 			warn(`Instance {instanceName} of Class {className} is intentionally opting out of attribute validation`)
 			return attributes
 		elseif attributes.Type == "StateScript" or instanceName == "StateScriptPart" then

--- a/Plugins/src/SerializationTools/Reading/Read.lua
+++ b/Plugins/src/SerializationTools/Reading/Read.lua
@@ -124,6 +124,17 @@ Read = {
 		local Z, cursor = Read.Float(str, cursor)
 		return Vector3.new(X, Y, Z), cursor
 	end,
+	
+	VectorMap = function(str, cursor)
+		if not VersionConfig.UseVectorMap then return {}, cursor end
+		local vectorMap, vectorMapLength
+		vectorMapLength, cursor = Read.LongInt(str, cursor)
+		vectorMap = table.create(vectorMapLength, Vector3.zero)
+		for i=1, vectorMapLength do
+			vectorMap[i], cursor = Read.Vector3(str, cursor)
+		end
+		return vectorMap, cursor
+	end,
 
 	UDim = function(str, cursor)
 		local udimVec
@@ -247,6 +258,7 @@ Read = {
 	end,
 
 	Mission = function(str, cursor)
+		
 		if str:sub(1, 3) == "!!!" then
 			local code = str:match("!!!.-!!!(.+)")
 			if not code then
@@ -263,11 +275,11 @@ Read = {
 		end
 		
 		Root = nil
-		local colorMap
+		local colorMap, stringMap, vectorMap
 		colorMap, cursor = Read.ColorMap(str, cursor)
-		local stringMap
 		stringMap, cursor = Read.StringMap(str, cursor)
-		local mission = Read.Instance(str, cursor, colorMap, stringMap)
+		vectorMap, cursor = Read.VectorMap(str, cursor)
+		local mission = Read.Instance(str, cursor, colorMap, stringMap, vectorMap)
 
 		-- Reading Color3s from TableMissionSetup
 		local ImportedMissionSetup = game:GetService("HttpService")
@@ -289,12 +301,12 @@ Read = {
 		return mission
 	end,
 
-	Instance = function(str, cursor, colorMap, stringMap)
+	Instance = function(str, cursor, colorMap, stringMap, vectorMap)
 		local InstanceId = StringConversion.StringToNumber(str, cursor, 1)
 		cursor += 1
 		if InstanceId ~= InstanceTypes.Nil then
 			local InstanceType = InstanceKeys[InstanceId]
-			local object, cursor = ReadInstance[InstanceType](str, cursor, Read, colorMap, stringMap)
+			local object, cursor = ReadInstance[InstanceType](str, cursor, Read, colorMap, stringMap, vectorMap)
 			if not Root and object.Name == `DebugMission` then
 				Root = object
 				Root:SetAttribute(`Loaded`, false)
@@ -302,7 +314,7 @@ Read = {
 			
 			while StringConversion.StringToNumber(str, cursor, 1) ~= 0 do
 				local child
-				child, cursor = Read.Instance(str, cursor, colorMap, stringMap)
+				child, cursor = Read.Instance(str, cursor, colorMap, stringMap, vectorMap)
 				if child ~= nil then
 					child.Parent = object
 				end

--- a/Plugins/src/SerializationTools/Reading/ReadInstance.lua
+++ b/Plugins/src/SerializationTools/Reading/ReadInstance.lua
@@ -8,15 +8,55 @@ local DefaultProperties = require(script.Parent.Parent.Types.DefaultProperties)
 local AttributeTypes = require(script.Parent.Parent.Types.AttributeTypes)
 local AttributeValidation = require(script.Parent.Parent.AttributeValidation)
 
+local VersionConfig = require(script.Parent.Parent.Util.VersionConfig)
+
 local AttributeKeys = {}
 for i, v in pairs(AttributeTypes) do
 	AttributeKeys[v] = i
 end
 
+local function readCFrame(str, cursor, read, vectorMap)
+	local pIdx, cursor = read.LongInt(str, cursor)
+	local xIdx, cursor = read.LongInt(str, cursor)
+	local yIdx, cursor = read.LongInt(str, cursor)
+	
+	local pos  = vectorMap[pIdx]
+	local xVec = vectorMap[xIdx]
+	local yVec = vectorMap[yIdx]
+	
+	return CFrame.fromMatrix(pos, xVec, yVec), cursor
+end
+
+local function readValue(str, cursor, read, vType, colorMap, stringMap, vectorMap, refHandler)
+	local value
+	if vType == "Color3" then
+		local colorMapIndex
+		colorMapIndex, cursor = read.ShortInt(str, cursor)
+		value = colorMap[colorMapIndex]
+	elseif vType == "String" then
+		local valueMapIndex
+		valueMapIndex, cursor = read.ShortInt(str, cursor)
+		value = stringMap[valueMapIndex]
+	elseif vType == "Vector3" and VersionConfig.UseVectorMap then
+		local vecMapIndex
+		vecMapIndex, cursor = read.LongInt(str, cursor)
+		value = vectorMap[vecMapIndex]
+	elseif vType == "CFrame" and VersionConfig.UseVectorMap then
+		value, cursor = readCFrame(str, cursor, read, vectorMap)
+	elseif vType == "InstanceReference" and refHandler ~= nil then
+		local set
+		set, cursor = read[vType](str, cursor)
+		task.spawn(refHandler, set)
+	else
+		value, cursor = read[vType](str, cursor)
+	end
+	return value, cursor
+end
+
 local WithAttributes = function(DefaultReader)
-	return function(str, cursor, Read, colorMap, stringMap)
+	return function(str, cursor, Read, colorMap, stringMap, vectorMap)
 		local newInstance
-		newInstance, cursor = DefaultReader(str, cursor, Read, colorMap, stringMap)
+		newInstance, cursor = DefaultReader(str, cursor, Read, colorMap, stringMap, vectorMap)
 		local attributeId = StringConversion.StringToNumber(str, cursor, 1)
 		cursor += 1
 		while not (attributeId == 0) do
@@ -25,17 +65,7 @@ local WithAttributes = function(DefaultReader)
 			nameMapIndex, cursor = Read.ShortInt(str, cursor)
 			local name = stringMap[nameMapIndex]
 			local value
-			if typeName == "Color3" then
-				local colorMapIndex
-				colorMapIndex, cursor = Read.ShortInt(str, cursor)
-				value = colorMap[colorMapIndex]
-			elseif typeName == "String" then
-				local valueMapIndex
-				valueMapIndex, cursor = Read.ShortInt(str, cursor)
-				value = stringMap[valueMapIndex]
-			else
-				value, cursor = Read[typeName](str, cursor)
-			end
+			value, cursor = readValue(str, cursor, Read, typeName, colorMap, stringMap, vectorMap)
 			newInstance:SetAttribute(name, value)
 			attributeId = StringConversion.StringToNumber(str, cursor, 1)
 			cursor += 1
@@ -54,7 +84,7 @@ local ReadInstance
 local CreateInstanceReader = function(instanceType, properties)
 	local defaults = DefaultProperties[instanceType]
 
-	local InstanceReader = function(str, cursor, Read, colorMap, stringMap)
+	local InstanceReader = function(str, cursor, Read, colorMap, stringMap, vectorMap)
 		local newInstance = Instance.new(instanceType)
 		if defaults then
 			for k, v in defaults do
@@ -69,23 +99,11 @@ local CreateInstanceReader = function(instanceType, properties)
 		while not (propertyId == 0) do
 			local typeName = properties[propertyId][1]
 			local valueType = properties[propertyId][2]
-			if valueType == "Color3" then
-				local colorMapIndex
-				colorMapIndex, cursor = Read.ShortInt(str, cursor)
-				newInstance[typeName] = colorMap[colorMapIndex]
-			elseif valueType == "String" then
-				local stringMapIndex
-				stringMapIndex, cursor = Read.ShortInt(str, cursor)
-				newInstance[typeName] = stringMap[stringMapIndex]
-			elseif valueType == "InstanceReference" then
-				local set, newCursor = Read[valueType](str, cursor)
-				cursor = newCursor
-				task.spawn(function()
-					newInstance[typeName] = set()
-				end)
-			else
-				newInstance[typeName], cursor = Read[valueType](str, cursor)
-			end
+			local value
+			value, cursor = readValue(str, cursor, Read, valueType, colorMap, stringMap, vectorMap, function(setter)
+				newInstance[typeName] = setter()
+			end)
+			if value ~= nil then newInstance[typeName] = value end
 			propertyId = StringConversion.StringToNumber(str, cursor, 1)
 			cursor += 1
 		end
@@ -107,7 +125,7 @@ end
 local CreateProtectedInstanceReader = function(instanceType, properties)
 	local defaults = DefaultProperties[instanceType]
 
-	local InstanceReader = function(str, cursor, Read, colorMap, stringMap)
+	local InstanceReader = function(str, cursor, Read, colorMap, stringMap, vectorMap)
 		local newProperties = {}
 		if defaults then
 			for k, v in defaults do
@@ -122,17 +140,7 @@ local CreateProtectedInstanceReader = function(instanceType, properties)
 		while not (propertyId == 0) do
 			local typeName = properties[propertyId][1]
 			local valueType = properties[propertyId][2]
-			if valueType == "Color3" then
-				local colorMapIndex
-				colorMapIndex, cursor = Read.ShortInt(str, cursor)
-				newProperties[typeName] = colorMap[colorMapIndex]
-			elseif valueType == "String" then
-				local stringMapIndex
-				stringMapIndex, cursor = Read.ShortInt(str, cursor)
-				newProperties[typeName] = stringMap[stringMapIndex]
-			else
-				newProperties[typeName], cursor = Read[valueType](str, cursor)
-			end
+			newProperties[typeName], cursor = readValue(str, cursor, Read, valueType, colorMap, stringMap, vectorMap)
 			propertyId = StringConversion.StringToNumber(str, cursor, 1)
 			cursor += 1
 		end

--- a/Plugins/src/SerializationTools/Util/VersionConfig.lua
+++ b/Plugins/src/SerializationTools/Util/VersionConfig.lua
@@ -1,9 +1,38 @@
-local VERSION_LATEST = 2
+local VERSION_LATEST = 3
+
+local settings = {
+	ReplaceNewlines = false,
+	UseCompression  = false,
+	UseVectorMap    = false,
+}
+local function vdef(tbl)
+	for k, _ in pairs(tbl) do
+		if settings[k] == nil then
+			warn(`Unrecognised version setting {k} - fix before submitting`)
+		end
+	end
+	
+	for k, default in pairs(settings) do
+		if tbl[k] == nil then
+			tbl[k] = default
+		end
+	end
+end
 
 local CODE_VERSION_LOOKUP = {
-	[0] = { ReplaceNewlines = false, UseCompression = false },
-	[1] = { ReplaceNewlines = true, UseCompression = false },
-	[2] = { ReplaceNewlines = true, UseCompression = true }
+	[0] = vdef{},
+	[1] = vdef{
+		ReplaceNewlines = true
+	},
+	[2] = vdef{
+		ReplaceNewlines = true,
+		UseCompression  = true,
+	},
+	[3] = vdef{
+		ReplaceNewlines = true,
+		UseCompression  = true,
+		UseVectorMap    = true
+	}
 }
 
 -- This works, Lua counts table lengths starting from 1
@@ -12,13 +41,15 @@ if #CODE_VERSION_LOOKUP > VERSION_LATEST then
 end
 
 local versionConfig = {
+	Distribution  = "Official",
 	LatestVersion = VERSION_LATEST,
 
 	VersionNumber = VERSION_LATEST,
 	VersionNumber_API = 1,
 	
 	ReplaceNewlines = true,
-	UseCompression  = true
+	UseCompression  = true,
+	UseVectorMap    = true
 }
 
 function versionConfig.change_version(self, to)
@@ -34,5 +65,7 @@ function versionConfig.change_version(self, to)
 end
 
 versionConfig:change_version(VERSION_LATEST)
+
+versionConfig.OfficialDistro = (versionConfig.Distribution == "Official")
 
 return versionConfig

--- a/Plugins/src/SerializationTools/Writing/Main.lua
+++ b/Plugins/src/SerializationTools/Writing/Main.lua
@@ -8,6 +8,7 @@ local ReadbackButton = require(script.Parent.ReadbackButton)
 
 local Button = require(script.Parent.Parent.Util.Button)
 local FeatureCheck = require(script.Parent.Parent.Util.FeatureCheck)
+local VersionConfig = require(script.Parent.Parent.Util.VersionConfig)
 local VisibilityToggle = require(script.Parent.Parent.Util.VisibilityToggle)
 
 local Actor = require(script.Parent.Parent.Util.Actor)
@@ -50,10 +51,16 @@ local function GetMissionSetting(missionRoot, settingName, settingType, defaultV
 	if not missionRoot.CustomMissionSettings:FindFirstChild(settingName) then
 		local setting = Instance.new(settingType)
 		setting.Name = settingName
-		setting.Value = defaultValue
+		if defaultValue ~= nil then
+			setting.Value = defaultValue
+		end
 		setting.Parent = missionRoot.CustomMissionSettings
 	end
 	return missionRoot.CustomMissionSettings[settingName]
+end
+
+local function SetMissionSetting(missionRoot, settingName, settingType, to)
+	GetMissionSetting(missionRoot, settingName, settingType, nil).Value = to
 end
 
 local function InitCustomMissionSettings(incrementVersionNumber)
@@ -63,7 +70,19 @@ local function InitCustomMissionSettings(incrementVersionNumber)
 	end
 
 	GetMissionSetting(mission, "EnforceCellLinks", "BoolValue", true)
-	local versionNumber = GetMissionSetting(mission, "ExportVersion", "StringValue", "0")
+	
+	local oldVersionValue = mission.CustomMissionSettings:FindFirstChild("ExportVersion")
+	if oldVersionValue ~= nil then
+		local newVersionValue = mission.CustomMissionSettings:FindFirstChild("MissionVersion")
+		if newVersionValue ~= nil then
+			oldVersionValue:Destroy()
+		else
+			warn("Renaming CustomMissionSettings.ExportVersion -> CustomMissionSettings.MissionVersion")
+			oldVersionValue.Name = "MissionVersion"
+		end
+	end
+	
+	local versionNumber = GetMissionSetting(mission, "MissionVersion", "StringValue", "0")
 	if incrementVersionNumber then
 		local front, minorVersion = versionNumber.Value:match("^(.-)(%d+)$")
 		if not (minorVersion and tonumber(minorVersion)) then
@@ -75,8 +94,49 @@ local function InitCustomMissionSettings(incrementVersionNumber)
 	GetMissionSetting(mission, "MissionName", "StringValue", "")
 	GetMissionSetting(mission, "MissionDesc", "StringValue", "")
 	GetMissionSetting(mission, "AuthorName", "StringValue", "")
+	local distro = GetMissionSetting(mission, "ExporterDistribution", "StringValue", VersionConfig.Distribution).Value
+	local version = tonumber(GetMissionSetting(mission, "ExporterVersion", "StringValue", tostring(VersionConfig.VersionNumber)).Value)
+	
+	if distro ~= VersionConfig.Distribution then
+		if VersionConfig.OfficialDistro then
+			warn("Exporter Distribution Mismatch!")
+			warn(`Current Exporter is "{VersionConfig.Distribution}", this mission was developed using "{distro}"`)
+			warn("Beware of the potential for undesirable behaviour!")
+		else
+			warn("Exporter Distribution Management")
+			warn("Detected you have began using an unofficial exporter version - updating CustomMissionSettings")
+			SetMissionSetting(mission, "ExporterDistribution", "StringValue", VersionConfig.Distribution)
+		end
+	end
+	
+	if version ~= VersionConfig.VersionNumber then
+		warn("Exporter Version Mismatch!")
+		warn(`Current Exporter is v{VersionConfig.VersionNumber}, this mission was developed on v{version}`)
+		warn("Double-check there's nothing unexpected")
+		warn(`If everything works fine, set the ExporterVersion in CustomMissionSettings to "{VersionConfig.VersionNumber}" to silence this warning`)
+	end
 
 	return mission.CustomMissionSettings
+end
+
+local function GetMissionComment(customSettings)
+	local linkWarn = customSettings.EnforceCellLinks.Value and "EnforceCellLinks is disabled on this map\nThis mission is ineligible to be featured in the community missions tab\n" or ""
+	
+	return table.concat({
+		"!!!\n",
+		linkWarn,
+		"How to play custom missions:\n",
+		`1) Join the game and find "Custom Mission" in the mission menu`,
+		`2) Start a custom mission lobby`,
+		`3) Go to the table and open the custom mission loader`,
+		`4) Copy the URL of this page into the box and hit enter. It will NOT work if you copy the contents of this page instead of the URL.\n`,
+		`Mission Name: {customSettings.MissionName.Value}`,
+		`Author(s): {customSettings.AuthorName.Value}`,
+		`Mission Version: {customSettings.MissionVersion.Value}`,
+		`Mission Briefing: {customSettings.MissionDesc.Value}`,
+		`ExporterID: {customSettings.ExporterDistribution.Value}_v{customSettings.ExporterVersion.Value}\n`,
+		"!!!"
+	}, '\n')
 end
 
 local function GetMissionCode()
@@ -157,7 +217,7 @@ module.Init = function(mouse: PluginMouse)
 
 					local output = Write.MissionCodeHeader(GenerateMapId(), 1, 1)
 					output = output .. code
-					output = `!!!{not customSettings.EnforceCellLinks.Value and "\n\nEnforceCellLinks is disabled on this map\nThis mission is ineligible to be featured in the community missions tab\n" or ""}\nHow to play custom missions:\n\n1) Join the game and find "Custom Mission" in the mission menu\n2) Start a custom mission lobby\n3) Go to the table and open the custom mission loader\n4) Copy the URL of this page into the box and hit enter. It will NOT work if you copy the contents of this page instead of the URL.\n\nMission Name: {customSettings.MissionName.Value}\nCreator: {customSettings.AuthorName.Value}\nVersion: {customSettings.ExportVersion.Value}\nBriefing: {customSettings.MissionDesc.Value}\n\n!!!`
+					output = GetMissionComment(customSettings)
 						.. output
 
 					if workspace:FindFirstChild("CustomMissionCode") then

--- a/Plugins/src/SerializationTools/Writing/Stats.lua
+++ b/Plugins/src/SerializationTools/Writing/Stats.lua
@@ -1,0 +1,29 @@
+-- Really basic stats module so I can check stuff like map hit-rate and whatever else I may throw in here
+
+local statKeys = {
+	LookupMap_Hits   = 0,
+	LookupMap_Misses = 0
+}
+
+local m = {}
+
+function m.output(self)
+	print("=== Writing Stats ===")
+	for k, _ in pairs(statKeys) do
+		print("\t" .. k, m[k])
+	end
+end
+
+function m.reset(self)
+	for k, default in pairs(statKeys) do
+		m[k] = default
+	end
+end
+
+function m.inc(self, key)
+	self[key] = self[key] + 1
+end
+
+m:reset()
+
+return m

--- a/Plugins/src/SerializationTools/Writing/Write.lua
+++ b/Plugins/src/SerializationTools/Writing/Write.lua
@@ -4,6 +4,7 @@ local WriteInstance = require(script.Parent.WriteInstance)
 
 local EncodingService = game:GetService("EncodingService")
 
+local WriteStats = require(script.Parent.Stats)
 local FeatureCheck = require(script.Parent.Parent.Util.FeatureCheck)
 
 local EnumTypes = require(script.Parent.Parent.Types.Enums.Main)
@@ -232,6 +233,16 @@ Write = {
 		end
 		return Write.ShortInt(#stringMap) .. stringStr
 	end,
+	
+	VectorMap = function(vectorMap)
+		if not VersionConfig.UseVectorMap then
+			return ""
+		end
+		for i, v in ipairs(vectorMap) do
+			vectorMap[i] = Write.Vector3(v)
+		end
+		return Write.LongInt(#vectorMap) .. table.concat(vectorMap)
+	end,
 
 	MissionCodeHeader = function(mapId, current, total)
 		local header = Write.ShortestInt(VersionConfig.VersionNumber)
@@ -242,6 +253,8 @@ Write = {
 	end,
 
 	Mission = function(mission)
+		WriteStats.reset()
+
 		local str = ""
 
 		local MissionSetup = require(mission:FindFirstChild("MissionSetup"):Clone())
@@ -273,14 +286,17 @@ Write = {
 		-- Numeric index so as to not have the size collide with existing values
 		local colorMap = { [0] = 0 }
 		local stringMap = { [0] = 0 }
+		local vectorMap = { [0] = 0 }
 
-		str, colorMap, stringMap = Write.Instance(mission, colorMap, stringMap)
+		str, colorMap, stringMap, vectorMap = Write.Instance(mission, colorMap, stringMap, vectorMap)
 
 		colorMap[0] = nil
 		stringMap[0] = nil
+		vectorMap[0] = nil
 
 		local colorMapArr = {}
 		local stringMapArr = {}
+		local vectorMapArr = {}
 
 		for colHex, colidx in pairs(colorMap) do
 			colorMapArr[colidx] = Color3.fromHex(colHex)
@@ -289,11 +305,16 @@ Write = {
 		for str, stridx in pairs(stringMap) do
 			stringMapArr[stridx] = str
 		end
+		
+		for vec, vecidx in pairs(vectorMap) do
+			vectorMapArr[vecidx] = vec
+		end
 
 		local colorMapStr = Write.ColorMap(colorMapArr)
 		local stringMapStr = Write.StringMap(stringMapArr)
+		local vectorMapStr = Write.VectorMap(vectorMapArr)
 
-		local missionStr = colorMapStr .. stringMapStr .. str
+		local missionStr = colorMapStr .. stringMapStr .. vectorMapStr .. str
 
 		if not VersionConfig.UseCompression then return missionStr end
 		
@@ -331,27 +352,32 @@ Write = {
 			print(`Before Compression: {#missionStr * 0.001}K`)
 			print(`After Compression: {#compressedStr * 0.001}K`)
 		end
+		
+		if FeatureCheck("SerializerDebug", false) == true then
+			WriteStats.output()
+		end
 
 		return compressedStr
 	end,
 
-	Instance = function(object, colorMap, stringMap)
+	Instance = function(object, colorMap, stringMap, vectorMap)
 		local className = object.ClassName
 		if InstanceTypes[object.ClassName] ~= nil then
 			if next(object:GetAttributes()) == nil and object.ClassName == "Part" then
 				className = className .. "NoAttributes"
 			end
 			local instanceType = StringConversion.NumberToString(InstanceTypes[className], 1)
-			local objectProperties, colorMap, stringMap = WriteInstance[className](object, Write, colorMap, stringMap)
+			local objectProperties, colorMap, stringMap, vectorMap = WriteInstance[className](object, Write, colorMap, stringMap, vectorMap)
 			local childrenProperties = ""
 			for i, v in pairs(object:GetChildren()) do
-				childrenProperties = childrenProperties .. Write.Instance(v, colorMap, stringMap)
+				childrenProperties = childrenProperties .. Write.Instance(v, colorMap, stringMap, vectorMap)
 			end
 			return instanceType .. objectProperties .. childrenProperties .. StringConversion.NumberToString(0, 1),
 			colorMap,
-			stringMap
+			stringMap,
+			vectorMap
 		else
-			return StringConversion.NumberToString(InstanceTypes.Nil, 1), colorMap, stringMap
+			return StringConversion.NumberToString(InstanceTypes.Nil, 1), colorMap, stringMap, vectorMap
 		end
 	end,
 

--- a/Plugins/src/SerializationTools/Writing/WriteInstance.lua
+++ b/Plugins/src/SerializationTools/Writing/WriteInstance.lua
@@ -3,7 +3,15 @@ local InstanceProperties = require(script.Parent.Parent.Types.InstanceProperties
 local AttributeTypes = require(script.Parent.Parent.Types.AttributeTypes)
 local AttributeValidation = require(script.Parent.Parent.AttributeValidation)
 
+local VersionConfig = require(script.Parent.Parent.Util.VersionConfig)
+
+local WriteStats = require(script.Parent.Stats)
+
 local function lookupMapIndex(map, value)
+	-- Vectors are supported here without any special casing due to a quirk of roblox lua
+	-- Wherein the "Vector3" roblox datatype corresponds to the "vector" value type
+	-- This is done for optimisation of vector maths, to my understanding, but it also leads to our desired value semantics
+	-- I.e. tbl[Vector3.one] == tbl[Vector3.new(1, 1, 1)]
 	if value == nil then
 		return 0
 	end
@@ -12,16 +20,50 @@ local function lookupMapIndex(map, value)
 	end
 	local idx = map[value]
 	if idx == nil then
+		WriteStats:inc("LookupMap_Misses")
 		idx = (map[0] + 1) -- Size + 1
 		map[value] = idx
 		map[0] = idx -- Update size
+	else
+		WriteStats:inc("LookupMap_Hits")
 	end
 	return idx
 end
 
+local function lookupMapCFrame(map, cfr)
+	local i1, i2, i3
+	local xVec = cfr.XVector
+	local yVec = cfr.YVector
+	
+	i1 = lookupMapIndex(map, cfr.Position)
+	i2 = lookupMapIndex(map, xVec)
+	i3 = lookupMapIndex(map, yVec)
+	return i1, i2, i3
+end
+
+local function representValue(write, v, vType, colorMap, stringMap, vectorMap)
+	local valStr
+	if vType == "Color3" then
+		local index = lookupMapIndex(colorMap, v)
+		valStr = write.ShortInt(index)
+	elseif vType == "String" then
+		local index = lookupMapIndex(stringMap, v)
+		valStr = write.ShortInt(index)
+	elseif vType == "Vector3" and VersionConfig.UseVectorMap then
+		local index = lookupMapIndex(vectorMap, v)
+		valStr = write.LongInt(index)
+	elseif vType == "CFrame" and VersionConfig.UseVectorMap then
+		local i1, i2, i3 = lookupMapCFrame(vectorMap, v)
+		valStr = write.LongInt(i1) .. write.LongInt(i2) .. write.LongInt(i3)
+	else
+		valStr = write[vType](v)
+	end
+	return valStr
+end
+
 local WithAttributes = function(DefaultWriter)
-	return function(object, Write, colorMap, stringMap)
-		local str = DefaultWriter(object, Write, colorMap, stringMap)
+	return function(object, Write, colorMap, stringMap, vectorMap)
+		local str = DefaultWriter(object, Write, colorMap, stringMap, vectorMap)
 		local attributes = object:GetAttributes()
 		attributes = AttributeValidation.Validate(object.ClassName, object.Name, attributes, false)
 		local attString = ""
@@ -51,24 +93,16 @@ local WithAttributes = function(DefaultWriter)
 			attString = attString
 				.. StringConversion.NumberToString(AttributeTypes[attributeType], 1)
 				.. Write.ShortInt(index)
-
-			if attributeType == "Color3" then
-				local index = lookupMapIndex(colorMap, v)
-				attString = attString .. Write.ShortInt(index)
-			elseif attributeType == "String" then
-				local index = lookupMapIndex(stringMap, v)
-				attString = attString .. Write.ShortInt(index)
-			else
-				attString = attString .. Write[attributeType](v)
-			end
+				.. representValue(Write, v, attributeType, colorMap, stringMap, vectorMap)
+			
 		end
 		str = str .. attString .. StringConversion.NumberToString(0, 1)
-		return str, colorMap, stringMap
+		return str, colorMap, stringMap, vectorMap
 	end
 end
 
 local CreateInstanceWriter = function(properties)
-	local WriteInstance = function(object, Write, colorMap, stringMap)
+	local WriteInstance = function(object, Write, colorMap, stringMap, vectorMap)
 		local str = ""
 		for i, v in pairs(properties) do
 			local value
@@ -79,24 +113,14 @@ local CreateInstanceWriter = function(properties)
 			end
 			local valueType = v[2]
 			local defaultValue = v[3]
-			if (valueType == "Color3") and (value ~= defaultValue) then
-				local index = lookupMapIndex(colorMap, value)
-				str = str .. StringConversion.NumberToString(i, 1)
-				str = str .. Write.ShortInt(index)
-				continue
-			elseif (valueType == "String") and (value ~= defaultValue) then
-				local index = lookupMapIndex(stringMap, value)
-				str = str .. StringConversion.NumberToString(i, 1)
-				str = str .. Write.ShortInt(index)
-				continue
-			elseif value ~= defaultValue then
-				str = str .. StringConversion.NumberToString(i, 1)
-				str = str .. Write[valueType](value)
-			end
+			
+			if value == defaultValue then continue end
+			
+			str = str .. StringConversion.NumberToString(i, 1) .. representValue(Write, value, valueType, colorMap, stringMap, vectorMap)
 		end
 
 		str = str .. StringConversion.NumberToString(0, 1)
-		return str, colorMap, stringMap
+		return str, colorMap, stringMap, vectorMap
 	end
 	return WriteInstance
 end


### PR DESCRIPTION
Adds the VectorMap mentioned in prior correspondence - when used these also overhaul CFrame serialization to use three vectors (position, x + y rotation columns), hopefully resolving the longstanding rotation precision issues.

Tested to work on an Import/Export of The Deposit - I hope I didn't miss some random prop somewhere becoming newly Australian.

This does unfortunately inflate the size of The Deposit by 10 kilobytes - I imagine you could make up some losses here by altering the precision of the X/Y rotation vectors, as (if I'm understanding correctly) should always have their components be between the range -1 <-> 1, this commit doesn't implement any such optimization on account of being very tired and wanting oh so badly to just go to bed right now.
<sub>Footnote: This additional cost may only noticeably affect smaller maps, I did not test the size difference in immense detail.</sub>

Some other changes did sneak into this commit, notably the discussed addition of `IgnoreValidation` as an alternative to the (*vastly* superior) `IKnowWhatImDoingDoNotValidate`, as well as a (currently extremely barebones) stats module, enabled by setting `SerializerDebug = true` on `workspace`.

The final extra feature to make it in is some conveniences to hopefully help flag version discrepancies, I've added the `ExporterDistribution` and `ExporterVersion` settings, which emit warnings when detected to be different from the versions supplied by the installed serializer. The `ExportVersion` setting has been renamed to `MissionVersion` to remove ambiguity - when upgrading it should be renamed automatically.
<sub>The ExporterDistribution value distinguishes between versions distributed from this repo ("Official") and any others. If anyone happens to be working on their own fork - please change this value!</sub>